### PR TITLE
DC-4644: Update play-language to remove transitive dependency url-builder

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,12 @@
 import com.lucidchart.sbt.scalafmt.ScalafmtCorePlugin.autoImport._
 import sbt.Keys._
-import sbt.Tests.{Group, SubProcess}
 import sbt._
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin._
 import uk.gov.hmrc._
 import DefaultBuildSettings._
-import uk.gov.hmrc.{SbtAutoBuildPlugin, SbtBuildInfo, ShellPrompt}
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin
-import uk.gov.hmrc.versioning.SbtGitVersioning
 import uk.gov.hmrc.versioning.SbtGitVersioning.autoImport.majorVersion
-import uk.gov.hmrc.ForkedJvmPerTestSettings.oneForkedJvmPerTest
-import sbt.Keys._
-import com.lucidchart.sbt.scalafmt.ScalafmtCorePlugin.autoImport._
-import play.sbt.routes.RoutesKeys._
+import uk.gov.hmrc.DefaultBuildSettings.oneForkedJvmPerTest
 
 val appName: String = "preferences-admin-frontend"
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -3,31 +3,31 @@
 ->          /hmrc-frontend                              hmrcfrontend.Routes
 GET         /assets/*file                               controllers.Assets.versioned(path = "/public", file: Asset)
 
-POST        /login                                      uk.gov.hmrc.preferencesadminfrontend.controllers.LoginController.loginAction
-POST        /logout                                     uk.gov.hmrc.preferencesadminfrontend.controllers.LoginController.logoutAction
-GET         /                                           uk.gov.hmrc.preferencesadminfrontend.controllers.LoginController.showLoginPage
-GET         /home                                       uk.gov.hmrc.preferencesadminfrontend.controllers.HomeController.showHomePage
+POST        /login                                      uk.gov.hmrc.preferencesadminfrontend.controllers.LoginController.loginAction()
+POST        /logout                                     uk.gov.hmrc.preferencesadminfrontend.controllers.LoginController.logoutAction()
+GET         /                                           uk.gov.hmrc.preferencesadminfrontend.controllers.LoginController.showLoginPage()
+GET         /home                                       uk.gov.hmrc.preferencesadminfrontend.controllers.HomeController.showHomePage()
 GET         /search                                     uk.gov.hmrc.preferencesadminfrontend.controllers.SearchController.showSearchPage()
 POST        /search/q                                   uk.gov.hmrc.preferencesadminfrontend.controllers.SearchController.search()
 POST        /search/opt-out                             uk.gov.hmrc.preferencesadminfrontend.controllers.SearchController.optOut()
-GET         /rescindment                                uk.gov.hmrc.preferencesadminfrontend.controllers.RescindmentController.showRescindmentPage
-GET         /rescindment/q                              uk.gov.hmrc.preferencesadminfrontend.controllers.RescindmentController.rescindmentAction
-GET         /rescindment/send                           uk.gov.hmrc.preferencesadminfrontend.controllers.RescindmentController.showRescindmentAlertsPage
-GET         /rescindment/send/q                         uk.gov.hmrc.preferencesadminfrontend.controllers.RescindmentController.sendRescindmentAlerts
-GET         /allowlist                                  uk.gov.hmrc.preferencesadminfrontend.controllers.AllowlistController.showAllowlistPage
-GET         /allowlist/add                              uk.gov.hmrc.preferencesadminfrontend.controllers.AllowlistController.addFormId
-POST        /allowlist/add                              uk.gov.hmrc.preferencesadminfrontend.controllers.AllowlistController.confirmAdd
+GET         /rescindment                                uk.gov.hmrc.preferencesadminfrontend.controllers.RescindmentController.showRescindmentPage()
+GET         /rescindment/q                              uk.gov.hmrc.preferencesadminfrontend.controllers.RescindmentController.rescindmentAction()
+GET         /rescindment/send                           uk.gov.hmrc.preferencesadminfrontend.controllers.RescindmentController.showRescindmentAlertsPage()
+GET         /rescindment/send/q                         uk.gov.hmrc.preferencesadminfrontend.controllers.RescindmentController.sendRescindmentAlerts()
+GET         /allowlist                                  uk.gov.hmrc.preferencesadminfrontend.controllers.AllowlistController.showAllowlistPage()
+GET         /allowlist/add                              uk.gov.hmrc.preferencesadminfrontend.controllers.AllowlistController.addFormId()
+POST        /allowlist/add                              uk.gov.hmrc.preferencesadminfrontend.controllers.AllowlistController.confirmAdd()
 GET         /allowlist/delete/:formId                   uk.gov.hmrc.preferencesadminfrontend.controllers.AllowlistController.deleteFormId(formId: String)
-POST        /allowlist/delete                           uk.gov.hmrc.preferencesadminfrontend.controllers.AllowlistController.confirmDelete
-GET         /message-brake                              uk.gov.hmrc.preferencesadminfrontend.controllers.MessageBrakeController.showAdminPage
-POST        /message-brake/preview                      uk.gov.hmrc.preferencesadminfrontend.controllers.MessageBrakeController.previewMessage
-GET         /message-brake/approve                      uk.gov.hmrc.preferencesadminfrontend.controllers.MessageBrakeController.showApproveBatchConfirmationPage
-GET         /message-brake/reject                       uk.gov.hmrc.preferencesadminfrontend.controllers.MessageBrakeController.showRejectBatchConfirmationPage
-POST        /message-brake/approve/confirmation         uk.gov.hmrc.preferencesadminfrontend.controllers.MessageBrakeController.confirmApproveBatch
-POST        /message-brake/reject/confirmation          uk.gov.hmrc.preferencesadminfrontend.controllers.MessageBrakeController.confirmRejectBatch
+POST        /allowlist/delete                           uk.gov.hmrc.preferencesadminfrontend.controllers.AllowlistController.confirmDelete()
+GET         /message-brake                              uk.gov.hmrc.preferencesadminfrontend.controllers.MessageBrakeController.showAdminPage()
+POST        /message-brake/preview                      uk.gov.hmrc.preferencesadminfrontend.controllers.MessageBrakeController.previewMessage()
+GET         /message-brake/approve                      uk.gov.hmrc.preferencesadminfrontend.controllers.MessageBrakeController.showApproveBatchConfirmationPage()
+GET         /message-brake/reject                       uk.gov.hmrc.preferencesadminfrontend.controllers.MessageBrakeController.showRejectBatchConfirmationPage()
+POST        /message-brake/approve/confirmation         uk.gov.hmrc.preferencesadminfrontend.controllers.MessageBrakeController.confirmApproveBatch()
+POST        /message-brake/reject/confirmation          uk.gov.hmrc.preferencesadminfrontend.controllers.MessageBrakeController.confirmRejectBatch()
 
 # Temporaty endpoits to migrate MDTP to ETMP
-GET         /migration                              uk.gov.hmrc.preferencesadminfrontend.controllers.MessageController.show
-POST        /migration                               uk.gov.hmrc.preferencesadminfrontend.controllers.MessageController.check
+GET         /migration                              uk.gov.hmrc.preferencesadminfrontend.controllers.MessageController.show()
+POST        /migration                               uk.gov.hmrc.preferencesadminfrontend.controllers.MessageController.check()
 
-POST        /migrate                               uk.gov.hmrc.preferencesadminfrontend.controllers.MessageController.sync
+POST        /migrate                               uk.gov.hmrc.preferencesadminfrontend.controllers.MessageController.sync()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -41,13 +41,6 @@ play.filters.headers.contentSecurityPolicy = "default-src 'self' 'unsafe-inline'
 
 play.http.errorHandler = "uk.gov.hmrc.preferencesadminfrontend.config.ErrorHandler"
 
-# Secret key
-# ~~~~~
-# The secret key is used to secure cryptographics functions.
-# If you deploy your application to several instances be sure to use the same key!
-play.crypto.secret = "WrlocbuBjgFBI3M7kVyHLAir1cpmCzaEIOXBQhz2h1AbtbMHwVvTexiGgfQH2tW9"
-
-
 featureFlag {
   migration = false
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,7 +8,7 @@ object AppDependencies {
     ws,
     "uk.gov.hmrc"                  %% "bootstrap-frontend-play-28" % "5.16.0",
     "com.vladsch.flexmark"         % "flexmark-all"                % "0.36.8",
-    "uk.gov.hmrc"                  %% "play-frontend-hmrc"         % "1.31.0-play-28",
+    "uk.gov.hmrc"                  %% "play-frontend-hmrc"         % "6.2.0-play-28",
     "uk.gov.hmrc"                  %% "auth-client"                % "5.7.0-play-28",
     "uk.gov.hmrc"                  %% "play-partials"              % "8.2.0-play-28",
     "com.typesafe.play"            %% "play-json-joda"             % "2.8.2",

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,7 +7,6 @@ object AppDependencies {
   val compile = Seq(
     ws,
     "uk.gov.hmrc"                  %% "bootstrap-frontend-play-28" % "5.16.0",
-    "com.vladsch.flexmark"         % "flexmark-all"                % "0.36.8",
     "uk.gov.hmrc"                  %% "play-frontend-hmrc"         % "6.2.0-play-28",
     "uk.gov.hmrc"                  %% "auth-client"                % "5.7.0-play-28",
     "uk.gov.hmrc"                  %% "play-partials"              % "8.2.0-play-28",
@@ -25,6 +24,7 @@ object AppDependencies {
     "org.scalatestplus.play" %% "scalatestplus-play"          % "5.1.0"   % Test,
     "org.mockito"            % "mockito-core"                 % "3.9.0"   % Test,
     "org.scalatestplus"      %% "mockito-3-4"                 % "3.2.8.0" % Test,
-    "org.scalamock"          %% "scalamock-scalatest-support" % "3.5.0"   % Test
+    "org.scalamock"          %% "scalamock-scalatest-support" % "3.5.0"   % Test,
+    "com.vladsch.flexmark"   % "flexmark-all"                 % "0.36.8"  % Test
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.7.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,9 +2,9 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.5.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.8.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"    % "2.1.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin"            % "2.8.7")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"            % "2.8.18")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"         % "1.6.1")
 addSbtPlugin("org.scalastyle"   %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("com.lucidchart"    % "sbt-scalafmt"          % "1.16")


### PR DESCRIPTION
Updating `play-frontend-hmrc` to the latest version which uses a later version of `play-language` that doesn't bring in `url-builder`