### PR TITLE
DC-9011 Paperless Admin - Bulk optout customers using file upload fun…

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,6 +4,7 @@ style = defaultWithAlign
 maxColumn = 120
 lineEndings = unix
 importSelectors = singleLine
+runner.dialectOverride.allowSignificantIndentation = false
 
 project {
   git = true

--- a/app/FrontendModule.scala
+++ b/app/FrontendModule.scala
@@ -14,11 +14,21 @@
  * limitations under the License.
  */
 
-import com.google.inject.AbstractModule
-import uk.gov.hmrc.preferencesadminfrontend.config.{ AppConfig, FrontendAppConfig }
+import com.google.inject.{ AbstractModule, Provides }
+import play.api.Configuration
+import uk.gov.hmrc.preferencesadminfrontend.config.{ AppConfig, BulkOptOutsConfig, FrontendAppConfig }
 
 class FrontendModule extends AbstractModule {
 
   override def configure(): Unit =
     bind(classOf[AppConfig]).to(classOf[FrontendAppConfig]).asEagerSingleton()
+
+  @Provides protected def provideFeatureSwitch(configuration: Configuration): BulkOptOutsConfig = {
+    val bulOptOutsConfigObject = configuration.get[Configuration]("bulkOptOuts")
+
+    BulkOptOutsConfig(
+      maxUploadEntries = bulOptOutsConfigObject.get("maxUploadEntries"),
+      maxOptOutsPerSecond = bulOptOutsConfigObject.get("maxOptOutsPerSecond")
+    )
+  }
 }

--- a/app/FrontendModule.scala
+++ b/app/FrontendModule.scala
@@ -23,7 +23,7 @@ class FrontendModule extends AbstractModule {
   override def configure(): Unit =
     bind(classOf[AppConfig]).to(classOf[FrontendAppConfig]).asEagerSingleton()
 
-  @Provides protected def provideFeatureSwitch(configuration: Configuration): BulkOptOutsConfig = {
+  @Provides protected def provideBulkOptOutsConfig(configuration: Configuration): BulkOptOutsConfig = {
     val bulOptOutsConfigObject = configuration.get[Configuration]("bulkOptOuts")
 
     BulkOptOutsConfig(

--- a/app/uk/gov/hmrc/preferencesadminfrontend/config/BulkOptOutsConfig.scala
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/config/BulkOptOutsConfig.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.preferencesadminfrontend.config
+
+case class BulkOptOutsConfig(maxUploadEntries: Int, maxOptOutsPerSecond: Int)

--- a/app/uk/gov/hmrc/preferencesadminfrontend/connectors/EntityResolverConnector.scala
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/connectors/EntityResolverConnector.scala
@@ -146,20 +146,27 @@ class EntityResolverConnector @Inject() (httpClient: HttpClientV2, val servicesC
     httpClient
       .post(new URI(s"$serviceUrl/entity-resolver-admin/manual-opt-out/${taxId.regime}/${taxId.value}").toURL)
       .execute[HttpResponse]
-      .map(_ => OptedOut)
-      .recover {
-        case _: NotFoundException =>
-          warnNotOptedOut(404)
-          PreferenceNotFound
-        case ex @ UpstreamErrorResponse(_, Status.CONFLICT, _, _) =>
-          warnNotOptedOut(ex.statusCode)
-          AlreadyOptedOut
-        case ex @ UpstreamErrorResponse(_, Status.NOT_FOUND, _, _) =>
-          warnNotOptedOut(ex.statusCode)
-          PreferenceNotFound
-        case ex @ UpstreamErrorResponse(_, Status.PRECONDITION_FAILED, _, _) =>
-          warnNotOptedOut(ex.statusCode)
-          PreferenceNotFound
+      .flatMap { httpResponse =>
+        httpResponse.status match {
+          case Status.OK =>
+            Future.successful(OptedOut)
+
+          case Status.CONFLICT =>
+            warnNotOptedOut(httpResponse.status)
+            Future.successful(AlreadyOptedOut)
+
+          case Status.NOT_FOUND =>
+            warnNotOptedOut(httpResponse.status)
+            Future.successful(PreferenceNotFound)
+
+          case Status.PRECONDITION_FAILED =>
+            Future.successful(PreferenceNotFound)
+
+          case _ =>
+            val exception = new RuntimeException(s"Unexpected opt out response for $taxId - $httpResponse")
+            logger.error(exception.getMessage, exception)
+            Future.failed(exception)
+        }
       }
   }
 

--- a/app/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadController.scala
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadController.scala
@@ -22,9 +22,11 @@ import play.api.i18n.I18nSupport
 import play.api.libs.Files
 import play.api.mvc.*
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
-import uk.gov.hmrc.preferencesadminfrontend.config.AppConfig
-import uk.gov.hmrc.preferencesadminfrontend.services.UploadService
+import uk.gov.hmrc.preferencesadminfrontend.config.{ AppConfig, BulkOptOutsConfig }
+import uk.gov.hmrc.preferencesadminfrontend.connectors.{ AlreadyOptedOut, OptedOut, PreferenceNotFound }
+import uk.gov.hmrc.preferencesadminfrontend.services.*
 import uk.gov.hmrc.preferencesadminfrontend.views.html.*
+
 import javax.inject.{ Inject, Singleton }
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -33,7 +35,11 @@ class CsvUploadController @Inject() (
   authorisedAction: AuthorisedAction,
   csvUpload: csv_upload,
   csvUploadConfirm: csv_upload_confirmation,
+  csvUploadBulkOptOuts: csv_upload_bulk_opt_outs,
+  csvUploadBulkOptOutConfirmation: cvs_upload_bulk_opt_confirmation,
   uploadService: UploadService,
+  bulkUploadOptOutsService: BulkUploadOptOutsService,
+  bulkOptOutsConfig: BulkOptOutsConfig,
   mcc: MessagesControllerComponents
 )(implicit appConfig: AppConfig, ec: ExecutionContext, actorSystem: ActorSystem)
     extends FrontendController(mcc) with I18nSupport with Logging with RoleAuthorisedAction(authorisedAction) {
@@ -58,5 +64,113 @@ class CsvUploadController @Inject() (
         .getOrElse {
           Future.successful(BadRequest(csvUploadConfirm("File missing or incorrect data supplied!")))
         }
+  }
+
+  val showBulkOptOutsUploadPage: Action[AnyContent] = authorisedAction { implicit request => _ =>
+    Future.successful(
+      Ok(
+        csvUploadBulkOptOuts(
+          maxUploads = bulkOptOutsConfig.maxUploadEntries,
+          errors = List.empty,
+          uploadedFileHadNoEntries = false,
+          tooManyEntriesWereUploadedCount = 0
+        )
+      )
+    )
+  }
+
+  def uploadBulkOptOuts(): Action[MultipartFormData[Files.TemporaryFile]] = Action.async(parse.multipartFormData) {
+    implicit request =>
+      request.body
+        .file("csvFile")
+        .map { filePart =>
+          processOptOutFileUpload(filePart)
+        }
+        .getOrElse {
+          Future.successful(
+            Ok(
+              csvUploadBulkOptOuts(
+                bulkOptOutsConfig.maxUploadEntries,
+                errors = List.empty,
+                uploadedFileHadNoEntries = true,
+                tooManyEntriesWereUploadedCount = 0
+              )
+            )
+          )
+        }
+  }
+
+  private def processOptOutFileUpload(
+    filePart: MultipartFormData.FilePart[Files.TemporaryFile]
+  )(implicit request: Request[_]) = {
+    val path = filePart.ref.path
+    val eventualErrorOrPotentialOptOuts = bulkUploadOptOutsService.readNinoBulkOptOutsFromFile(path)
+
+    eventualErrorOrPotentialOptOuts.flatMap { errorOrOptOutList =>
+      if (errorOrOptOutList.isEmpty) {
+        Future.successful(
+          Ok(
+            csvUploadBulkOptOuts(
+              maxUploads = bulkOptOutsConfig.maxUploadEntries,
+              errors = List.empty,
+              uploadedFileHadNoEntries = true,
+              tooManyEntriesWereUploadedCount = 0
+            )
+          )
+        )
+      } else {
+        val errors = errorOrOptOutList.collect { case Left(error) => error }
+        val successfulEntries = errorOrOptOutList.collect { case Right(success) => success }
+        val uploadedCount = errorOrOptOutList.length
+        val hasTooManyUploads = uploadedCount > bulkOptOutsConfig.maxUploadEntries
+
+        if (errors.nonEmpty || hasTooManyUploads) {
+          val tooManyEntriesWereUploadedCount = if (hasTooManyUploads) {
+            uploadedCount
+          } else {
+            0
+          }
+
+          Future.successful(
+            Ok(
+              csvUploadBulkOptOuts(
+                maxUploads = bulkOptOutsConfig.maxUploadEntries,
+                errors = errors,
+                uploadedFileHadNoEntries = false,
+                tooManyEntriesWereUploadedCount = tooManyEntriesWereUploadedCount
+              )
+            )
+          )
+        } else {
+          bulkUploadOptOutsService.processBulkOptOuts(successfulEntries).map { bulkOptOutResults =>
+            showBulkOptOutConfirmation(bulkOptOutResults)
+          }
+        }
+      }
+    }
+  }
+
+  private def showBulkOptOutConfirmation(
+    bulkOptOutResults: List[BulkOptOutResult]
+  )(implicit request: Request[_]): Result = {
+    val failedCallNinos = bulkOptOutResults.collect { case failedCall: FailedCallBulkOptOutResult =>
+      failedCall.nino
+    }
+    val successfullyOptedOutNinos =
+      bulkOptOutResults.collect { case ProcessedBulkOptOutResult(nino, OptedOut) => nino }
+    val alreadyOptedOutNinos =
+      bulkOptOutResults.collect { case ProcessedBulkOptOutResult(nino, AlreadyOptedOut) => nino }
+    val notFoundNinos = bulkOptOutResults.collect { case ProcessedBulkOptOutResult(nino, PreferenceNotFound) =>
+      nino
+    }
+
+    Ok(
+      csvUploadBulkOptOutConfirmation(
+        successfullyOptedOutNinos = successfullyOptedOutNinos,
+        alreadyOptedOutNinos = alreadyOptedOutNinos,
+        notFoundNinos = notFoundNinos,
+        failedCallNinos = failedCallNinos
+      )
+    )
   }
 }

--- a/app/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadController.scala
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadController.scala
@@ -16,10 +16,9 @@
 
 package uk.gov.hmrc.preferencesadminfrontend.controllers
 
-import cats.data.EitherT
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.scaladsl.Framing
-import play.api.{ Logger, Logging }
+import play.api.Logging
 import play.api.i18n.I18nSupport
 import play.api.libs.Files
 import play.api.mvc.*

--- a/app/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadController.scala
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadController.scala
@@ -16,8 +16,10 @@
 
 package uk.gov.hmrc.preferencesadminfrontend.controllers
 
+import cats.data.EitherT
 import org.apache.pekko.actor.ActorSystem
-import play.api.Logging
+import org.apache.pekko.stream.scaladsl.Framing
+import play.api.{ Logger, Logging }
 import play.api.i18n.I18nSupport
 import play.api.libs.Files
 import play.api.mvc.*
@@ -29,7 +31,6 @@ import uk.gov.hmrc.preferencesadminfrontend.views.html.*
 
 import javax.inject.{ Inject, Singleton }
 import scala.concurrent.{ ExecutionContext, Future }
-
 @Singleton
 class CsvUploadController @Inject() (
   authorisedAction: AuthorisedAction,
@@ -73,6 +74,7 @@ class CsvUploadController @Inject() (
           maxUploads = bulkOptOutsConfig.maxUploadEntries,
           errors = List.empty,
           uploadedFileHadNoEntries = false,
+          uploadedFileWasInvalid = false,
           tooManyEntriesWereUploadedCount = 0
         )
       )
@@ -84,7 +86,27 @@ class CsvUploadController @Inject() (
       request.body
         .file("csvFile")
         .map { filePart =>
-          processOptOutFileUpload(filePart)
+          val path = filePart.ref.path
+          val eventualErrorOrPotentialOptOuts = bulkUploadOptOutsService.readNinoBulkOptOutsFromFile(path)
+
+          eventualErrorOrPotentialOptOuts.flatMap {
+            case Left(framingException: Framing.FramingException) =>
+              logger.error("Failed uploading bulk opt outs file", framingException)
+
+              Future.successful(
+                Ok(
+                  csvUploadBulkOptOuts(
+                    maxUploads = bulkOptOutsConfig.maxUploadEntries,
+                    errors = List.empty,
+                    uploadedFileHadNoEntries = false,
+                    uploadedFileWasInvalid = true,
+                    tooManyEntriesWereUploadedCount = 0
+                  )
+                )
+              )
+            case Right(errorOrOptOutList) =>
+              processOptOutFileUpload(errorOrOptOutList)
+          }
         }
         .getOrElse {
           Future.successful(
@@ -93,6 +115,7 @@ class CsvUploadController @Inject() (
                 bulkOptOutsConfig.maxUploadEntries,
                 errors = List.empty,
                 uploadedFileHadNoEntries = true,
+                uploadedFileWasInvalid = false,
                 tooManyEntriesWereUploadedCount = 0
               )
             )
@@ -101,54 +124,50 @@ class CsvUploadController @Inject() (
   }
 
   private def processOptOutFileUpload(
-    filePart: MultipartFormData.FilePart[Files.TemporaryFile]
-  )(implicit request: Request[_]) = {
-    val path = filePart.ref.path
-    val eventualErrorOrPotentialOptOuts = bulkUploadOptOutsService.readNinoBulkOptOutsFromFile(path)
+    errorOrOptOutList: List[Either[String, String]]
+  )(implicit request: Request[_]): Future[Result] =
+    if (errorOrOptOutList.isEmpty) {
+      Future.successful(
+        Ok(
+          csvUploadBulkOptOuts(
+            maxUploads = bulkOptOutsConfig.maxUploadEntries,
+            errors = List.empty,
+            uploadedFileHadNoEntries = true,
+            uploadedFileWasInvalid = false,
+            tooManyEntriesWereUploadedCount = 0
+          )
+        )
+      )
+    } else {
+      val errors = errorOrOptOutList.collect { case Left(error) => error }
+      val successfulEntries = errorOrOptOutList.collect { case Right(success) => success }
+      val uploadedCount = errorOrOptOutList.length
+      val hasTooManyUploads = uploadedCount > bulkOptOutsConfig.maxUploadEntries
 
-    eventualErrorOrPotentialOptOuts.flatMap { errorOrOptOutList =>
-      if (errorOrOptOutList.isEmpty) {
+      if (errors.nonEmpty || hasTooManyUploads) {
+        val tooManyEntriesWereUploadedCount = if (hasTooManyUploads) {
+          uploadedCount
+        } else {
+          0
+        }
+
         Future.successful(
           Ok(
             csvUploadBulkOptOuts(
               maxUploads = bulkOptOutsConfig.maxUploadEntries,
-              errors = List.empty,
-              uploadedFileHadNoEntries = true,
-              tooManyEntriesWereUploadedCount = 0
+              errors = errors,
+              uploadedFileHadNoEntries = false,
+              uploadedFileWasInvalid = false,
+              tooManyEntriesWereUploadedCount = tooManyEntriesWereUploadedCount
             )
           )
         )
       } else {
-        val errors = errorOrOptOutList.collect { case Left(error) => error }
-        val successfulEntries = errorOrOptOutList.collect { case Right(success) => success }
-        val uploadedCount = errorOrOptOutList.length
-        val hasTooManyUploads = uploadedCount > bulkOptOutsConfig.maxUploadEntries
-
-        if (errors.nonEmpty || hasTooManyUploads) {
-          val tooManyEntriesWereUploadedCount = if (hasTooManyUploads) {
-            uploadedCount
-          } else {
-            0
-          }
-
-          Future.successful(
-            Ok(
-              csvUploadBulkOptOuts(
-                maxUploads = bulkOptOutsConfig.maxUploadEntries,
-                errors = errors,
-                uploadedFileHadNoEntries = false,
-                tooManyEntriesWereUploadedCount = tooManyEntriesWereUploadedCount
-              )
-            )
-          )
-        } else {
-          bulkUploadOptOutsService.processBulkOptOuts(successfulEntries).map { bulkOptOutResults =>
-            showBulkOptOutConfirmation(bulkOptOutResults)
-          }
+        bulkUploadOptOutsService.processBulkOptOuts(successfulEntries).map { bulkOptOutResults =>
+          showBulkOptOutConfirmation(bulkOptOutResults)
         }
       }
     }
-  }
 
   private def showBulkOptOutConfirmation(
     bulkOptOutResults: List[BulkOptOutResult]

--- a/app/uk/gov/hmrc/preferencesadminfrontend/services/BulkUploadOptOutsService.scala
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/services/BulkUploadOptOutsService.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.preferencesadminfrontend.services
+
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{ Sink, Source }
+import play.api.Logging
+import uk.gov.hmrc.domain.Nino
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.preferencesadminfrontend.config.BulkOptOutsConfig
+import uk.gov.hmrc.preferencesadminfrontend.connectors.{ EntityResolverConnector, OptOutResult }
+import uk.gov.hmrc.preferencesadminfrontend.services.model.TaxIdentifier
+
+import java.nio.file.Path
+import javax.inject.Inject
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.Try
+
+sealed trait BulkOptOutResult
+case class FailedCallBulkOptOutResult(nino: String) extends BulkOptOutResult
+case class ProcessedBulkOptOutResult(nino: String, optOutResult: OptOutResult) extends BulkOptOutResult
+
+class BulkUploadOptOutsService @Inject() (
+  csvReader: CsvReader,
+  entityResolverConnector: EntityResolverConnector,
+  bulkOptOutsConfig: BulkOptOutsConfig
+) extends Logging {
+
+  def readNinoBulkOptOutsFromFile(
+    path: Path
+  )(implicit mat: Materializer): Future[List[Either[String, String]]] = {
+    val extractCsvData: PartialFunction[Any, Either[String, String]] = {
+      case line: String if line.split(",").map(_.trim).length >= 1 =>
+        val cols = line.split(",").map(_.trim)
+        val ninoValue = cols(0)
+        val hasValue = !cols.zipWithIndex.exists { case (value, index) =>
+          index > 0 & value.nonEmpty
+        }
+
+        if (hasValue && Try(Nino(ninoValue)).isSuccess) {
+          Right(ninoValue)
+        } else {
+          Left(line)
+        }
+    }
+
+    csvReader.readFromFile(path, extractCsvData)
+  }
+
+  def processBulkOptOuts(
+    ninos: List[String]
+  )(implicit ec: ExecutionContext, mat: Materializer, hc: HeaderCarrier): Future[List[BulkOptOutResult]] =
+    Source(ninos)
+      .throttle(bulkOptOutsConfig.maxOptOutsPerSecond, 1.second)
+      .mapAsync(parallelism = 2) { nino =>
+        entityResolverConnector
+          .optOut(TaxIdentifier.ninoIdentifier(nino))
+          .map { optOutResult =>
+            ProcessedBulkOptOutResult(nino, optOutResult)
+          }
+          .recover { case throwable: Throwable =>
+            logger.error(s"Bulk opt out processing failed for nino $nino record", throwable)
+            FailedCallBulkOptOutResult(nino)
+          }
+      }
+      .runWith(Sink.seq)
+      .map(_.toList)
+}

--- a/app/uk/gov/hmrc/preferencesadminfrontend/services/BulkUploadOptOutsService.scala
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/services/BulkUploadOptOutsService.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.preferencesadminfrontend.services
 
 import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Framing.FramingException
 import org.apache.pekko.stream.scaladsl.{ Sink, Source }
 import play.api.Logging
 import uk.gov.hmrc.domain.Nino
@@ -39,11 +40,12 @@ class BulkUploadOptOutsService @Inject() (
   csvReader: CsvReader,
   entityResolverConnector: EntityResolverConnector,
   bulkOptOutsConfig: BulkOptOutsConfig
-) extends Logging {
+)(implicit ec: ExecutionContext)
+    extends Logging {
 
   def readNinoBulkOptOutsFromFile(
     path: Path
-  )(implicit mat: Materializer): Future[List[Either[String, String]]] = {
+  )(implicit mat: Materializer): Future[Either[FramingException, List[Either[String, String]]]] = {
     val extractCsvData: PartialFunction[Any, Either[String, String]] = {
       case line: String if line.split(",").map(_.trim).length >= 1 =>
         val cols = line.split(",").map(_.trim)
@@ -59,7 +61,10 @@ class BulkUploadOptOutsService @Inject() (
         }
     }
 
-    csvReader.readFromFile(path, extractCsvData)
+    csvReader
+      .readFromFile(path, extractCsvData)
+      .map(Right[FramingException, List[Either[String, String]]].apply)
+      .recover { case e: FramingException => Left(e) }
   }
 
   def processBulkOptOuts(

--- a/app/uk/gov/hmrc/preferencesadminfrontend/services/CsvReader.scala
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/services/CsvReader.scala
@@ -24,9 +24,13 @@ import java.nio.file.Path
 import javax.inject.Inject
 import scala.concurrent.Future
 
+object CsvReader {
+  val FrameLength: Int = 1024
+}
+
 class CsvReader @Inject() {
 
-  private val FrameLength = 1024
+  private val FrameLength = CsvReader.FrameLength
   private val AllowTruncation = true
 
   def readFromFile[A](path: Path, collectFilter: PartialFunction[Any, A])(implicit

--- a/app/uk/gov/hmrc/preferencesadminfrontend/services/model/TaxIdentifier.scala
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/services/model/TaxIdentifier.scala
@@ -25,10 +25,13 @@ case class TaxIdentifier(name: String, value: String) {
     case "nino"        => "paye"
     case "email"       => "email"
     case "HMRC-MTD-IT" => "itsa"
-    case _             => throw new RuntimeException("Invalid tax id name")
+    case _             => throw new RuntimeException(s"Invalid tax id name '$name'")
   }
 }
 
 object TaxIdentifier {
   implicit val format: OFormat[TaxIdentifier] = Json.format[TaxIdentifier]
+
+  def ninoIdentifier(value: String): TaxIdentifier =
+    TaxIdentifier("nino", value)
 }

--- a/app/uk/gov/hmrc/preferencesadminfrontend/views/csv_upload_bulk_opt_outs.scala.html
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/views/csv_upload_bulk_opt_outs.scala.html
@@ -21,6 +21,7 @@
     maxUploads: Int,
     errors:List[String],
     uploadedFileHadNoEntries: Boolean,
+    uploadedFileWasInvalid: Boolean,
     tooManyEntriesWereUploadedCount : Int
 )(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
@@ -45,12 +46,22 @@
                     Upload a CSV file For Bulk Opt Outs (Maximum @maxUploads)
                 </label>
 
+                @if(uploadedFileWasInvalid ){
+                    @govukWarningText(WarningText(
+                        iconFallbackText = Some("Warning"),
+                        content = Text(s"The uploaded file could not be processed")
+                    ))
+                }
+
+
                 @if(tooManyEntriesWereUploadedCount > 0){
                     @govukWarningText(WarningText(
                         iconFallbackText = Some("Warning"),
                         content = Text(s"Too many entries were uploaded ($tooManyEntriesWereUploadedCount)")
                     ))
                 }
+
+
 
                 @if(errors.nonEmpty){
                     <div class="govuk-body">

--- a/app/uk/gov/hmrc/preferencesadminfrontend/views/csv_upload_bulk_opt_outs.scala.html
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/views/csv_upload_bulk_opt_outs.scala.html
@@ -1,0 +1,81 @@
+@*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.preferencesadminfrontend.controllers.routes
+
+@this(layout: Layout, govukBreadcrumbs: GovukBreadcrumbs, form: FormWithCSRF,govukWarningText : GovukWarningText)
+@(
+    maxUploads: Int,
+    errors:List[String],
+    uploadedFileHadNoEntries: Boolean,
+    tooManyEntriesWereUploadedCount : Int
+)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+
+@layout(pageTitle = "CSV Bulk Opt Outs Upload Page") {
+
+    @govukBreadcrumbs(Breadcrumbs(
+        items = Seq(
+            BreadcrumbsItem(
+                content = Text("Home"),
+                href = Some("#")
+            ),
+            BreadcrumbsItem(
+                content = Text("Bulk Opt Out"),
+                href = Some("/paperless/admin/csv-upload-bulk-opt-outs")
+            ),
+        )
+    ))
+
+        @form(action = routes.CsvUploadController.uploadBulkOptOuts(), Symbol("enctype")-> "multipart/form-data") {
+            <div class="govuk-form-group">
+                <label class="govuk-heading-m" for="csv-upload">
+                    Upload a CSV file For Bulk Opt Outs (Maximum @maxUploads)
+                </label>
+
+                @if(tooManyEntriesWereUploadedCount > 0){
+                    @govukWarningText(WarningText(
+                        iconFallbackText = Some("Warning"),
+                        content = Text(s"Too many entries were uploaded ($tooManyEntriesWereUploadedCount)")
+                    ))
+                }
+
+                @if(errors.nonEmpty){
+                    <div class="govuk-body">
+                        @govukWarningText(WarningText(
+                            iconFallbackText = Some("Warning"),
+                            content = Text("The following uploaded entries were invalid")
+                        ))
+
+                        <ul class="govuk-task-list">
+                        @for(error <- errors){
+                            <li class="govuk-task-list__item">@error</li>
+                        }
+                        </ul>
+                    </div>
+                }
+
+                @if(uploadedFileHadNoEntries){
+                    @govukWarningText(WarningText(
+                        iconFallbackText = Some("Warning"),
+                        content = Text("The uploaded file had no entries")
+                    ))
+                }
+
+                <input class="govuk-file-upload" id="csv-upload" name="csvFile" type="file" accept=".csv">
+            </div>
+            <button type="submit" id="submit" data-module="govuk-button" class="govuk-button" >Upload and Process</button>
+        }
+}

--- a/app/uk/gov/hmrc/preferencesadminfrontend/views/csv_upload_bulk_opt_outs.scala.html
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/views/csv_upload_bulk_opt_outs.scala.html
@@ -30,7 +30,7 @@
         items = Seq(
             BreadcrumbsItem(
                 content = Text("Home"),
-                href = Some("#")
+                href = Some("/paperless/admin/home")
             ),
             BreadcrumbsItem(
                 content = Text("Bulk Opt Out"),

--- a/app/uk/gov/hmrc/preferencesadminfrontend/views/cvs_upload_bulk_opt_confirmation.scala.html
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/views/cvs_upload_bulk_opt_confirmation.scala.html
@@ -31,7 +31,7 @@
   items = Seq(
    BreadcrumbsItem(
     content = Text("Home"),
-    href = Some("#")
+    href = Some("/paperless/admin/home")
    ),
    BreadcrumbsItem(
     content = Text("Bulk Opt Out"),

--- a/app/uk/gov/hmrc/preferencesadminfrontend/views/cvs_upload_bulk_opt_confirmation.scala.html
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/views/cvs_upload_bulk_opt_confirmation.scala.html
@@ -1,0 +1,92 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import java.time.format.DateTimeFormatter
+@import java.util.Locale
+
+@this(layout: Layout, govukBreadcrumbs: GovukBreadcrumbs, govukWarningText : GovukWarningText)
+
+@(
+    successfullyOptedOutNinos: List[String],
+    alreadyOptedOutNinos: List[String],
+    notFoundNinos: List[String],
+  failedCallNinos: Seq[String]
+)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+
+@layout(pageTitle = "Bulk Upload Opt Out Confirmation") {
+ @govukBreadcrumbs(Breadcrumbs(
+  items = Seq(
+   BreadcrumbsItem(
+    content = Text("Home"),
+    href = Some("#")
+   ),
+   BreadcrumbsItem(
+    content = Text("Bulk Opt Out"),
+    href = Some("/paperless/admin/csv-upload-bulk-opt-outs")
+   ),
+  )
+ ))
+
+    <div id="file-upload-confirmation">
+        <h2 class="govuk-heading-m">File Upload Confirmation</h2>
+
+     @if(alreadyOptedOutNinos.nonEmpty){
+      @govukWarningText(WarningText(
+       iconFallbackText = Some("Warning"),
+       content = Text("The following uploaded entries were already opted out")
+      ))
+
+      <ul class="govuk-task-list">
+      @for(alreadyOptedOutNino <- alreadyOptedOutNinos){
+       <li class="govuk-task-list__item">@alreadyOptedOutNino</li>
+      }
+      </ul>
+     }
+
+     @if(notFoundNinos.nonEmpty){
+      @govukWarningText(WarningText(
+       iconFallbackText = Some("Warning"),
+       content = Text("The following uploaded entries were not found")
+      ))
+
+      <ul class="govuk-task-list">
+      @for(notFoundNino <- notFoundNinos){
+       <li class="govuk-task-list__item">@notFoundNino</li>
+      }
+      </ul>
+     }
+
+     @if(failedCallNinos.nonEmpty){
+      @govukWarningText(WarningText(
+       iconFallbackText = Some("Warning"),
+       content = Text("The following entries failed for unexpected reasons")
+      ))
+
+      <ul class="govuk-task-list">
+      @for(failedCallNino <- failedCallNinos){
+       <li class="govuk-task-list__item">@failedCallNino</li>
+      }
+      </ul>
+     }
+
+     <p class="govuk-heading-m">Successfully opted out @successfullyOptedOutNinos.length records</p>
+     <ul class="govuk-task-list">
+      @for(successfulNino <- successfullyOptedOutNinos){
+       <li class="govuk-task-list__item">@successfulNino</li>
+      }
+     </ul>
+    </div>
+}

--- a/app/uk/gov/hmrc/preferencesadminfrontend/views/home.scala.html
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/views/home.scala.html
@@ -50,7 +50,10 @@
                 <a class="govuk-link govuk-task-list__link" href="/paperless/admin/multi-search">Multi Search</a>
             </li>
             <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                <a class="govuk-link govuk-task-list__link" href="/paperless/admin/csv-upload">File Upload</a>
+                <a class="govuk-link govuk-task-list__link" href="/paperless/admin/csv-upload">File Upload Id Updates</a>
+            </li>
+            <li class="govuk-task-list__item govuk-task-list__item--with-link">
+                <a class="govuk-link govuk-task-list__link" href="/paperless/admin/csv-upload-bulk-opt-outs">Bulk Opt Out</a>
             </li>
             }
         </ul>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -26,6 +26,10 @@ POST        /message-brake/approve/confirmation         uk.gov.hmrc.preferencesa
 POST        /message-brake/reject/confirmation          uk.gov.hmrc.preferencesadminfrontend.controllers.MessageBrakeController.confirmRejectBatch()
 GET         /csv-upload                                 uk.gov.hmrc.preferencesadminfrontend.controllers.CsvUploadController.showUploadPage()
 POST        /csv-upload/confirmation                    uk.gov.hmrc.preferencesadminfrontend.controllers.CsvUploadController.upload()
+GET         /csv-upload-bulk-opt-outs                   uk.gov.hmrc.preferencesadminfrontend.controllers.CsvUploadController.showBulkOptOutsUploadPage
+POST        /csv-upload-bulk-opt-outs/confirmation      uk.gov.hmrc.preferencesadminfrontend.controllers.CsvUploadController.uploadBulkOptOuts()
+
+
 # Temporaty endpoits to migrate MDTP to ETMP
 GET         /migration                              uk.gov.hmrc.preferencesadminfrontend.controllers.MessageController.show()
 POST        /migration                               uk.gov.hmrc.preferencesadminfrontend.controllers.MessageController.check()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -34,6 +34,11 @@ google-analytics {
   host = auto
 }
 
+bulkOptOuts {
+   maxUploadEntries = 100
+   maxOptOutsPerSecond = 10
+}
+
 users = [
     {
       username = "user"

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,9 +3,11 @@ import sbt._
 object AppDependencies {
 
   val bootstrapVersion = "10.7.0"
+  val hmrcDomainVersion = "13.0.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"   %% "bootstrap-frontend-play-30" % bootstrapVersion,
+    "uk.gov.hmrc"   %% "domain-play-30"             % hmrcDomainVersion,
     "uk.gov.hmrc"   %% "play-frontend-hmrc-play-30" % "12.32.0",
     "org.typelevel" %% "cats-core"                  % "2.13.0"
   )

--- a/project/ScoverageSettings.scala
+++ b/project/ScoverageSettings.scala
@@ -15,7 +15,7 @@
  */
 
 import sbt.Keys.parallelExecution
-import sbt.{Def, *}
+import sbt.{ Def, * }
 import scoverage.ScoverageKeys
 
 object ScoverageSettings {

--- a/test/uk/gov/hmrc/preferencesadminfrontend/connectors/EntityResolverConnectorSpec.scala
+++ b/test/uk/gov/hmrc/preferencesadminfrontend/connectors/EntityResolverConnectorSpec.scala
@@ -290,34 +290,28 @@ class EntityResolverConnectorSpec extends PlaySpec with ScalaFutures with GuiceO
     "return true if status is OK (user is opted out)" in new TestCase {
       val expectedPath = url"$entityResolverserviceUrl/entity-resolver-admin/manual-opt-out/sa/${sautr.value}"
 
-      val result = entityConnectorPostMock(expectedPath).optOut(sautr).futureValue
+      val result = entityConnectorPostMock(expectedPath, Status.OK).optOut(sautr).futureValue
 
       result mustBe OptedOut
     }
 
     "return false if CONFLICT" in new TestCase {
       val expectedPath = url"$entityResolverserviceUrl/entity-resolver-admin/manual-opt-out/sa/${sautr.value}"
-
-      val error = UpstreamErrorResponse("", Status.CONFLICT, Status.CONFLICT)
-      val result = entityConnectorPostMock(expectedPath, error).optOut(sautr).futureValue
+      val result = entityConnectorPostMock(expectedPath, Status.CONFLICT).optOut(sautr).futureValue
 
       result mustBe AlreadyOptedOut
     }
 
     "return false if NOT_FOUND" in new TestCase {
       val expectedPath = url"$entityResolverserviceUrl/entity-resolver-admin/manual-opt-out/sa/${sautr.value}"
-
-      val error = UpstreamErrorResponse("", Status.NOT_FOUND, Status.NOT_FOUND)
-      val result = entityConnectorPostMock(expectedPath, error).optOut(sautr).futureValue
+      val result = entityConnectorPostMock(expectedPath, Status.NOT_FOUND).optOut(sautr).futureValue
 
       result mustBe PreferenceNotFound
     }
 
     "return false if PRECONDITION_FAILED" in new TestCase {
       val expectedPath = url"$entityResolverserviceUrl/entity-resolver-admin/manual-opt-out/sa/${sautr.value}"
-
-      val error = UpstreamErrorResponse("", Status.PRECONDITION_FAILED, Status.PRECONDITION_FAILED)
-      val result = entityConnectorPostMock(expectedPath, error).optOut(sautr).futureValue
+      val result = entityConnectorPostMock(expectedPath, Status.PRECONDITION_FAILED).optOut(sautr).futureValue
 
       result mustBe PreferenceNotFound
     }
@@ -360,17 +354,6 @@ class EntityResolverConnectorSpec extends PlaySpec with ScalaFutures with GuiceO
         result mustBe None
       }
     }
-
-    "optOut" should {
-      "handle NotFoundException specifically" in new TestCase {
-        val expectedPath = url"$entityResolverserviceUrl/entity-resolver-admin/manual-opt-out/sa/${sautr.value}"
-        val result = entityConnectorPostMock(expectedPath, new uk.gov.hmrc.http.NotFoundException("404"))
-          .optOut(sautr)
-          .futureValue
-        result mustBe PreferenceNotFound
-      }
-    }
-
   }
 
   class TestCase {
@@ -414,17 +397,6 @@ class EntityResolverConnectorSpec extends PlaySpec with ScalaFutures with GuiceO
 
       when(mockHttp.get(eql(expectedPath))(any)).thenReturn(requestBuilder)
       when(requestBuilder.execute[HttpResponse](any, any)).thenReturn(Future.failed(error))
-
-      new EntityResolverConnector(mockHttp, servicesConfig)
-    }
-
-    def entityConnectorPostMock(expectedPath: URL): EntityResolverConnector = {
-      lazy val mockResponse = mock[HttpResponse]
-      val mockHttp: HttpClientV2 = mock[HttpClientV2]
-      val requestBuilder: RequestBuilder = mock[RequestBuilder]
-
-      when(mockHttp.post(eql(expectedPath))(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute[HttpResponse](any, any)).thenReturn(Future.successful(mockResponse))
 
       new EntityResolverConnector(mockHttp, servicesConfig)
     }

--- a/test/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadControllerSpec.scala
+++ b/test/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadControllerSpec.scala
@@ -17,12 +17,14 @@
 package uk.gov.hmrc.preferencesadminfrontend.controllers
 
 import org.apache.pekko.stream.Materializer
+import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.*
 import org.mockito.Mockito.*
+import org.scalactic.source.Position
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import org.scalatestplus.play.{ HtmlUnitFactory, PlaySpec }
 import play.api.http.*
 import play.api.i18n.MessagesApi
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -33,21 +35,22 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import play.api.{ Application, inject }
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.preferencesadminfrontend.connectors.{ AlreadyOptedOut, OptedOut, PreferenceNotFound }
 import uk.gov.hmrc.preferencesadminfrontend.controllers.model.User
-import uk.gov.hmrc.preferencesadminfrontend.services.UploadService
+import uk.gov.hmrc.preferencesadminfrontend.services.*
 import uk.gov.hmrc.preferencesadminfrontend.utils.SpecBase
 
 import java.nio.file.Path
 import scala.concurrent.{ ExecutionContext, Future }
 
 class CsvUploadControllerSpec
-    extends PlaySpec with GuiceOneAppPerSuite with SpecBase with ScalaFutures with MockitoSugar {
+    extends PlaySpec with GuiceOneAppPerSuite with SpecBase with ScalaFutures with MockitoSugar with HtmlUnitFactory {
 
   implicit lazy val materializer: Materializer = app.materializer
   override implicit lazy val app: Application = GuiceApplicationBuilder().build()
   implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
 
-  "GET /csv-upload" should {
+  "showUploadPage (GET /csv-upload)" should {
     "return 200" in new TestCase {
       val result: Future[Result] =
         controller.showUploadPage()(FakeRequest("GET", "/decode").withSession(User.sessionKey -> "admin"))
@@ -68,7 +71,7 @@ class CsvUploadControllerSpec
     }
   }
 
-  "POST /csv-upload/confirmation" should {
+  "upload (POST /csv-upload/confirmation)" should {
     "return 400 when form binding fails" in new TestCase {
       val request = FakeRequest("POST", "/csv-upload/confirmation")
         .withSession(User.sessionKey -> "admin")
@@ -78,7 +81,7 @@ class CsvUploadControllerSpec
       status(result) mustBe BAD_REQUEST
     }
 
-    "return 200 when service returns nil " in new TestCase {
+    "return 200 when service returns nil" in new TestCase {
       val mockTemporaryFile = mock[TemporaryFile]
       val mockPath = mock[Path]
 
@@ -98,6 +101,7 @@ class CsvUploadControllerSpec
       )
       when(mockUploadService.readFromFile(any())(any()))
         .thenReturn(Future.successful(Nil))
+
       when(mockUploadService.process(any())(any(), any(), any()))
         .thenReturn(Future.successful("success"))
 
@@ -111,11 +115,330 @@ class CsvUploadControllerSpec
     }
   }
 
+  "showBulkOptOutsUploadPage (GET /csv-upload-bulk-opt-outs)" should {
+    "return HTML" in new TestCase {
+      val result: Future[Result] =
+        controller.showBulkOptOutsUploadPage()(FakeRequest("", "").withSession(User.sessionKey -> "admin"))
+
+      contentType(result) mustBe Some("text/html")
+      charset(result) mustBe Some("utf-8")
+      status(result) mustBe OK
+    }
+
+    "redirect to login page for non-admin user" in new TestCase {
+      val result: Future[Result] =
+        controller.showBulkOptOutsUploadPage()(FakeRequest("GET", "/decode"))
+      status(result) mustBe Status.SEE_OTHER
+    }
+  }
+
+  "uploadBulkOptOuts (POST /csv-upload-bulk-opt-outs/confirmation)" should {
+    def filePart: FilePart[TemporaryFile] = FilePart(
+      key = "csvFile",
+      filename = "test.csv",
+      contentType = Some("text/csv"),
+      ref = mock[TemporaryFile]
+    )
+
+    "return 400 when form binding fails" in new TestCase {
+      val request = FakeRequest("", "")
+        .withSession(User.sessionKey -> "admin")
+
+      val result = controller.uploadBulkOptOuts()(request)
+
+      status(result) mustBe BAD_REQUEST
+    }
+
+    "return 200 but display errors when some could not be validated" in new TestCase {
+      val mockTemporaryFile = mock[TemporaryFile]
+      val mockPath = mock[Path]
+
+      when(mockTemporaryFile.path).thenReturn(mockPath)
+
+      when(mockBulkOptOutsService.readNinoBulkOptOutsFromFile(any())(any()))
+        .thenReturn(
+          Future.successful(
+            List(
+              Right("nino1"),
+              Left("error1,sss"),
+              Right("nino2"),
+              Left("error2,sss")
+            )
+          )
+        )
+
+      val formData = MultipartFormData[TemporaryFile](
+        dataParts = Map.empty,
+        files = Seq(filePart),
+        badParts = Seq.empty
+      )
+
+      val request = FakeRequest("", "")
+        .withSession(User.sessionKey -> "admin")
+        .withBody(formData)
+
+      val result = controller.uploadBulkOptOuts()(request)
+
+      status(result) mustBe OK
+      val body: String = contentAsString(result)
+
+      extractNulkOptOutErrors(body) mustBe List(
+        "The following uploaded entries were invalid"
+      )
+
+      body must include("error1,sss")
+      body must include("error2,sss")
+
+      body must not include "nino1"
+      body must not include "nino2"
+
+    }
+
+    def extractNulkOptOutErrors(body: String): List[String] = {
+      val possibleErrorMessages = List(
+        "The following uploaded entries were already opted out",
+        "The following uploaded entries were not found",
+        "The following uploaded entries were invalid",
+        "The following entries failed for unexpected reasons",
+        "The uploaded file had no entries",
+        "Too many entries were uploaded"
+      )
+
+      possibleErrorMessages.collect {
+        case possibleError if body.contains(possibleError) =>
+          possibleError
+      }
+
+    }
+
+    "return 200 but display no entries were found if file was empty" in new TestCase {
+      val mockTemporaryFile = mock[TemporaryFile]
+      val mockPath = mock[Path]
+
+      when(mockTemporaryFile.path).thenReturn(mockPath)
+
+      when(mockBulkOptOutsService.readNinoBulkOptOutsFromFile(any())(any()))
+        .thenReturn(
+          Future.successful(List.empty)
+        )
+
+      val formData = MultipartFormData[TemporaryFile](
+        dataParts = Map.empty,
+        files = Seq(filePart),
+        badParts = Seq.empty
+      )
+
+      val request = FakeRequest("", "")
+        .withSession(User.sessionKey -> "admin")
+        .withBody(formData)
+
+      val result = controller.uploadBulkOptOuts()(request)
+
+      status(result) mustBe OK
+      val body: String = contentAsString(result)
+
+      extractNulkOptOutErrors(body) mustBe List(
+        "The uploaded file had no entries"
+      )
+    }
+
+    "return 200 but display too many entries if the limit is exceeded" in new TestCase {
+      val mockTemporaryFile = mock[TemporaryFile]
+      val mockPath = mock[Path]
+
+      val ninos = (1 to 101).map { index =>
+        s"nino-$index"
+      }.toList
+
+      when(mockTemporaryFile.path).thenReturn(mockPath)
+
+      when(mockBulkOptOutsService.readNinoBulkOptOutsFromFile(any())(any()))
+        .thenReturn(
+          Future.successful(ninos.map(Right.apply))
+        )
+
+      val formData = MultipartFormData[TemporaryFile](
+        dataParts = Map.empty,
+        files = Seq(filePart),
+        badParts = Seq.empty
+      )
+
+      val request = FakeRequest("", "")
+        .withSession(User.sessionKey -> "admin")
+        .withBody(formData)
+
+      val result = controller.uploadBulkOptOuts()(request)
+
+      status(result) mustBe OK
+      val body: String = contentAsString(result)
+
+      extractNulkOptOutErrors(body) mustBe List(
+        "Too many entries were uploaded"
+      )
+    }
+
+    def testValidParsing(
+      controller: CsvUploadController,
+      mockBulkOptOutsService: BulkUploadOptOutsService,
+      ninos: List[String],
+      serverResponse: List[BulkOptOutResult],
+      expectedErrors: List[String],
+      successCount: Int
+    )(implicit position: Position): Unit = {
+      val mockTemporaryFile = mock[TemporaryFile]
+      val mockPath = mock[Path]
+
+      when(mockTemporaryFile.path).thenReturn(mockPath)
+
+      val formData = MultipartFormData[TemporaryFile](
+        dataParts = Map.empty,
+        files = Seq(filePart),
+        badParts = Seq.empty
+      )
+
+      when(mockBulkOptOutsService.readNinoBulkOptOutsFromFile(any())(any()))
+        .thenReturn(
+          Future.successful(
+            ninos.map(Right.apply)
+          )
+        )
+
+      when(mockBulkOptOutsService.processBulkOptOuts(ArgumentMatchers.eq(ninos))(any(), any(), any()))
+        .thenReturn(
+          Future.successful(
+            serverResponse
+          )
+        )
+
+      val request = FakeRequest("", "")
+        .withSession(User.sessionKey -> "admin")
+        .withBody(formData)
+
+      val result = controller.uploadBulkOptOuts()(request)
+
+      status(result) mustBe OK
+      val body: String = contentAsString(result)
+
+      extractNulkOptOutErrors(body) mustBe expectedErrors
+      body must include(s"Successfully opted out $successCount records")
+    }
+
+    "return 200 when only valid entries that were at maximum upload count were parsed and processed successfully as opted out" in new TestCase {
+      val ninos = (1 to 100).map { index =>
+        s"nino-$index"
+      }.toList
+
+      testValidParsing(
+        controller = controller,
+        mockBulkOptOutsService = mockBulkOptOutsService,
+        ninos = ninos,
+        serverResponse = ninos.map(nino => ProcessedBulkOptOutResult(nino, OptedOut)),
+        expectedErrors = List.empty,
+        successCount = ninos.size
+      )
+    }
+
+    "return 200 when only valid entries were parsed but were already opted out" in new TestCase {
+      val ninos = List(
+        "nino1",
+        "nino2"
+      )
+
+      testValidParsing(
+        controller = controller,
+        mockBulkOptOutsService = mockBulkOptOutsService,
+        ninos = ninos,
+        serverResponse = List(
+          ProcessedBulkOptOutResult("nino1", AlreadyOptedOut),
+          ProcessedBulkOptOutResult("nino2", AlreadyOptedOut)
+        ),
+        expectedErrors = List("The following uploaded entries were already opted out"),
+        successCount = 0
+      )
+    }
+
+    "return 200 when only valid entries were parsed but were not found" in new TestCase {
+      val ninos = List(
+        "nino1",
+        "nino2"
+      )
+
+      testValidParsing(
+        controller = controller,
+        mockBulkOptOutsService = mockBulkOptOutsService,
+        ninos = ninos,
+        serverResponse = List(
+          ProcessedBulkOptOutResult("nino1", PreferenceNotFound),
+          ProcessedBulkOptOutResult("nino2", PreferenceNotFound)
+        ),
+        expectedErrors = List("The following uploaded entries were not found"),
+        successCount = 0
+      )
+    }
+
+    "return 200 when only valid entries were parsed but failed for unknown reasons" in new TestCase {
+      val ninos = List(
+        "nino1",
+        "nino2"
+      )
+
+      testValidParsing(
+        controller = controller,
+        mockBulkOptOutsService = mockBulkOptOutsService,
+        ninos = ninos,
+        serverResponse = List(
+          FailedCallBulkOptOutResult("nino1"),
+          FailedCallBulkOptOutResult("nino2")
+        ),
+        expectedErrors = List("The following entries failed for unexpected reasons"),
+        successCount = 0
+      )
+    }
+
+    "return 200 and display all combinations of reponses" in new TestCase {
+      val ninos = List(
+        "nino1",
+        "nino2",
+        "nino3",
+        "nino4",
+        "nino5",
+        "nino6",
+        "nino7",
+        "nino8"
+      )
+
+      testValidParsing(
+        controller = controller,
+        mockBulkOptOutsService = mockBulkOptOutsService,
+        ninos = ninos,
+        serverResponse = List(
+          ProcessedBulkOptOutResult("nino1", PreferenceNotFound),
+          ProcessedBulkOptOutResult("nino2", OptedOut),
+          FailedCallBulkOptOutResult("nino3"),
+          FailedCallBulkOptOutResult("nino4"),
+          ProcessedBulkOptOutResult("nino5", AlreadyOptedOut),
+          ProcessedBulkOptOutResult("nino6", AlreadyOptedOut),
+          ProcessedBulkOptOutResult("nino7", OptedOut),
+          ProcessedBulkOptOutResult("nino8", OptedOut)
+        ),
+        expectedErrors = List(
+          "The following uploaded entries were already opted out",
+          "The following uploaded entries were not found",
+          "The following entries failed for unexpected reasons"
+        ),
+        successCount = 3
+      )
+    }
+
+  }
+
   class TestCase {
     lazy val mockUploadService: UploadService = mock[UploadService]
+    lazy val mockBulkOptOutsService: BulkUploadOptOutsService = mock[BulkUploadOptOutsService]
 
     implicit lazy val app: Application = GuiceApplicationBuilder()
       .overrides(inject.bind[UploadService].toInstance(mockUploadService))
+      .overrides(inject.bind[BulkUploadOptOutsService].toInstance(mockBulkOptOutsService))
       .build()
 
     implicit val hc: HeaderCarrier = HeaderCarrier()
@@ -125,4 +448,5 @@ class CsvUploadControllerSpec
 
     lazy val controller: CsvUploadController = app.injector.instanceOf[CsvUploadController]
   }
+
 }

--- a/test/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadControllerSpec.scala
+++ b/test/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadControllerSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.preferencesadminfrontend.controllers
 
 import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Framing.FramingException
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.*
 import org.mockito.Mockito.*
@@ -123,12 +124,32 @@ class CsvUploadControllerSpec
       contentType(result) mustBe Some("text/html")
       charset(result) mustBe Some("utf-8")
       status(result) mustBe OK
+
+      extractBulkOptOutErrors(contentAsString(result)) mustBe List.empty
     }
 
     "redirect to login page for non-admin user" in new TestCase {
       val result: Future[Result] =
         controller.showBulkOptOutsUploadPage()(FakeRequest("GET", "/decode"))
       status(result) mustBe Status.SEE_OTHER
+
+    }
+  }
+
+  def extractBulkOptOutErrors(body: String): List[String] = {
+    val possibleErrorMessages = List(
+      "The following uploaded entries were already opted out",
+      "The following uploaded entries were not found",
+      "The following uploaded entries were invalid",
+      "The following entries failed for unexpected reasons",
+      "The uploaded file had no entries",
+      "Too many entries were uploaded",
+      "The uploaded file could not be processed"
+    )
+
+    possibleErrorMessages.collect {
+      case possibleError if body.contains(possibleError) =>
+        possibleError
     }
   }
 
@@ -149,7 +170,7 @@ class CsvUploadControllerSpec
       status(result) mustBe BAD_REQUEST
     }
 
-    "return 200 but display errors when some could not be validated" in new TestCase {
+    "return 200 but display a message saying the file could not be processed when it fails processing" in new TestCase {
       val mockTemporaryFile = mock[TemporaryFile]
       val mockPath = mock[Path]
 
@@ -158,11 +179,8 @@ class CsvUploadControllerSpec
       when(mockBulkOptOutsService.readNinoBulkOptOutsFromFile(any())(any()))
         .thenReturn(
           Future.successful(
-            List(
-              Right("nino1"),
-              Left("error1,sss"),
-              Right("nino2"),
-              Left("error2,sss")
+            Left(
+              new FramingException("failed reading file")
             )
           )
         )
@@ -182,36 +200,12 @@ class CsvUploadControllerSpec
       status(result) mustBe OK
       val body: String = contentAsString(result)
 
-      extractNulkOptOutErrors(body) mustBe List(
-        "The following uploaded entries were invalid"
+      extractBulkOptOutErrors(body) mustBe List(
+        "The uploaded file could not be processed"
       )
-
-      body must include("error1,sss")
-      body must include("error2,sss")
-
-      body must not include "nino1"
-      body must not include "nino2"
-
     }
 
-    def extractNulkOptOutErrors(body: String): List[String] = {
-      val possibleErrorMessages = List(
-        "The following uploaded entries were already opted out",
-        "The following uploaded entries were not found",
-        "The following uploaded entries were invalid",
-        "The following entries failed for unexpected reasons",
-        "The uploaded file had no entries",
-        "Too many entries were uploaded"
-      )
-
-      possibleErrorMessages.collect {
-        case possibleError if body.contains(possibleError) =>
-          possibleError
-      }
-
-    }
-
-    "return 200 but display no entries were found if file was empty" in new TestCase {
+    "return 200 but display errors when some could not be validated" in new TestCase {
       val mockTemporaryFile = mock[TemporaryFile]
       val mockPath = mock[Path]
 
@@ -219,7 +213,16 @@ class CsvUploadControllerSpec
 
       when(mockBulkOptOutsService.readNinoBulkOptOutsFromFile(any())(any()))
         .thenReturn(
-          Future.successful(List.empty)
+          Future.successful(
+            Right(
+              List(
+                Right("nino1"),
+                Left("error1,sss"),
+                Right("nino2"),
+                Left("error2,sss")
+              )
+            )
+          )
         )
 
       val formData = MultipartFormData[TemporaryFile](
@@ -237,7 +240,45 @@ class CsvUploadControllerSpec
       status(result) mustBe OK
       val body: String = contentAsString(result)
 
-      extractNulkOptOutErrors(body) mustBe List(
+      extractBulkOptOutErrors(body) mustBe List(
+        "The following uploaded entries were invalid"
+      )
+
+      body must include("error1,sss")
+      body must include("error2,sss")
+
+      body must not include "nino1"
+      body must not include "nino2"
+
+    }
+
+    "return 200 but display no entries were found if file was empty" in new TestCase {
+      val mockTemporaryFile = mock[TemporaryFile]
+      val mockPath = mock[Path]
+
+      when(mockTemporaryFile.path).thenReturn(mockPath)
+
+      when(mockBulkOptOutsService.readNinoBulkOptOutsFromFile(any())(any()))
+        .thenReturn(
+          Future.successful(Right(List.empty))
+        )
+
+      val formData = MultipartFormData[TemporaryFile](
+        dataParts = Map.empty,
+        files = Seq(filePart),
+        badParts = Seq.empty
+      )
+
+      val request = FakeRequest("", "")
+        .withSession(User.sessionKey -> "admin")
+        .withBody(formData)
+
+      val result = controller.uploadBulkOptOuts()(request)
+
+      status(result) mustBe OK
+      val body: String = contentAsString(result)
+
+      extractBulkOptOutErrors(body) mustBe List(
         "The uploaded file had no entries"
       )
     }
@@ -254,7 +295,7 @@ class CsvUploadControllerSpec
 
       when(mockBulkOptOutsService.readNinoBulkOptOutsFromFile(any())(any()))
         .thenReturn(
-          Future.successful(ninos.map(Right.apply))
+          Future.successful(Right(ninos.map(Right.apply)))
         )
 
       val formData = MultipartFormData[TemporaryFile](
@@ -272,7 +313,7 @@ class CsvUploadControllerSpec
       status(result) mustBe OK
       val body: String = contentAsString(result)
 
-      extractNulkOptOutErrors(body) mustBe List(
+      extractBulkOptOutErrors(body) mustBe List(
         "Too many entries were uploaded"
       )
     }
@@ -299,7 +340,7 @@ class CsvUploadControllerSpec
       when(mockBulkOptOutsService.readNinoBulkOptOutsFromFile(any())(any()))
         .thenReturn(
           Future.successful(
-            ninos.map(Right.apply)
+            Right(ninos.map(Right.apply))
           )
         )
 
@@ -319,7 +360,7 @@ class CsvUploadControllerSpec
       status(result) mustBe OK
       val body: String = contentAsString(result)
 
-      extractNulkOptOutErrors(body) mustBe expectedErrors
+      extractBulkOptOutErrors(body) mustBe expectedErrors
       body must include(s"Successfully opted out $successCount records")
     }
 

--- a/test/uk/gov/hmrc/preferencesadminfrontend/services/BulkUploadOptOutsServiceSpec.scala
+++ b/test/uk/gov/hmrc/preferencesadminfrontend/services/BulkUploadOptOutsServiceSpec.scala
@@ -18,8 +18,11 @@ package uk.gov.hmrc.preferencesadminfrontend.services
 
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Framing
+import org.apache.pekko.stream.scaladsl.Framing.FramingException
 import org.mockito.Mockito.when
 import org.scalactic.Prettifier
+import org.scalactic.source.Position
 import org.scalatest.concurrent.{ IntegrationPatience, ScalaFutures }
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -52,10 +55,36 @@ class BulkUploadOptOutsServiceSpec
   // not used in comparison but in showing a clear diff on failure
   private implicit val prettifier: Prettifier = {
     case entries: Seq[_] => entries.mkString(",\n").stripSuffix("\n")
-    case o: Any          => o.toString
+    case right: Right[_, _] =>
+      right.value match {
+        case entries: Seq[_] => entries.mkString(",\n").stripSuffix("\n")
+        case _               => right.toString
+      }
+
+    case o: Any => o.toString
   }
 
   "readBulkOptOutsFromFile" should {
+
+    "return an error if the file is invalid" in {
+      val csvContent =
+        s"""${"a".repeat(CsvReader.FrameLength + 1).mkString}
+           |""".stripMargin
+
+      val tempFile: Path = Files.createTempFile("test-upload", ".csv")
+      Files.write(tempFile, csvContent.getBytes("UTF-8"))
+
+      try {
+        val eventualErrorOrCvBulkOptOutCsvDataList
+          : Future[Either[Framing.FramingException, List[Either[String, String]]]] =
+          bulkUploadOptOutsService.readNinoBulkOptOutsFromFile(tempFile)
+        whenReady(eventualErrorOrCvBulkOptOutCsvDataList) { errorOrCvOptOutCsvDataList =>
+          errorOrCvOptOutCsvDataList.left.map(_.getClass) mustBe Left(classOf[FramingException])
+
+        }
+      } finally Files.deleteIfExists(tempFile)
+    }
+
     "parse an empty csv file returning an empty list" in {
       val csvContent = ""
 
@@ -63,10 +92,10 @@ class BulkUploadOptOutsServiceSpec
       Files.write(tempFile, csvContent.getBytes("UTF-8"))
 
       try {
-        val eventualCvBulkOptOutCsvDataList: Future[List[Either[String, String]]] =
+        val eventualCvBulkOptOutCsvDataList: Future[Either[Framing.FramingException, List[Either[String, String]]]] =
           bulkUploadOptOutsService.readNinoBulkOptOutsFromFile(tempFile)
         whenReady(eventualCvBulkOptOutCsvDataList) { cvOptOutCsvDataList =>
-          cvOptOutCsvDataList mustBe List.empty
+          cvOptOutCsvDataList mustBe Right(List.empty)
         }
       } finally Files.deleteIfExists(tempFile)
     }
@@ -89,13 +118,15 @@ class BulkUploadOptOutsServiceSpec
         val cvOptOutCsvDataList =
           bulkUploadOptOutsService.readNinoBulkOptOutsFromFile(tempFile).futureValue
 
-        cvOptOutCsvDataList mustBe List(
-          Right("YY336119A"),
-          Right("YY336119B"),
-          Left("YY336119A, unexpected value"),
-          Left(", YY336119A"),
-          Right("YY336119C"),
-          Left("invalidformat")
+        cvOptOutCsvDataList mustBe Right(
+          List(
+            Right("YY336119A"),
+            Right("YY336119B"),
+            Left("YY336119A, unexpected value"),
+            Left(", YY336119A"),
+            Right("YY336119C"),
+            Left("invalidformat")
+          )
         )
 
       } finally Files.deleteIfExists(tempFile)

--- a/test/uk/gov/hmrc/preferencesadminfrontend/services/BulkUploadOptOutsServiceSpec.scala
+++ b/test/uk/gov/hmrc/preferencesadminfrontend/services/BulkUploadOptOutsServiceSpec.scala
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.preferencesadminfrontend.services
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
+import org.mockito.Mockito.when
+import org.scalactic.Prettifier
+import org.scalatest.concurrent.{ IntegrationPatience, ScalaFutures }
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.preferencesadminfrontend.config.BulkOptOutsConfig
+import uk.gov.hmrc.preferencesadminfrontend.connectors.*
+import uk.gov.hmrc.preferencesadminfrontend.services.model.TaxIdentifier
+
+import java.nio.file.{ Files, Path }
+import scala.concurrent.{ ExecutionContextExecutor, Future }
+
+class BulkUploadOptOutsServiceSpec
+    extends AnyWordSpecLike with Matchers with ScalaFutures with IntegrationPatience with MockitoSugar {
+
+  implicit val system: ActorSystem = ActorSystem("UploadServiceSpec")
+
+  implicit val mat: Materializer = Materializer(system)
+  implicit val executionContext: ExecutionContextExecutor = mat.executionContext
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+
+  private val mockEntityResolverConnector: EntityResolverConnector = mock[EntityResolverConnector]
+  private val bulkUploadOptOutsService =
+    new BulkUploadOptOutsService(
+      new CsvReader,
+      mockEntityResolverConnector,
+      BulkOptOutsConfig(maxUploadEntries = 100, maxOptOutsPerSecond = 10)
+    )
+
+  // not used in comparison but in showing a clear diff on failure
+  private implicit val prettifier: Prettifier = {
+    case entries: Seq[_] => entries.mkString(",\n").stripSuffix("\n")
+    case o: Any          => o.toString
+  }
+
+  "readBulkOptOutsFromFile" should {
+    "parse an empty csv file returning an empty list" in {
+      val csvContent = ""
+
+      val tempFile: Path = Files.createTempFile("test-upload", ".csv")
+      Files.write(tempFile, csvContent.getBytes("UTF-8"))
+
+      try {
+        val eventualCvBulkOptOutCsvDataList: Future[List[Either[String, String]]] =
+          bulkUploadOptOutsService.readNinoBulkOptOutsFromFile(tempFile)
+        whenReady(eventualCvBulkOptOutCsvDataList) { cvOptOutCsvDataList =>
+          cvOptOutCsvDataList mustBe List.empty
+        }
+      } finally Files.deleteIfExists(tempFile)
+    }
+
+    "parse a valid CSV file returning failed rows and successful rows in a processable format ignoring extra empty values" in {
+      val csvContent =
+        """YY336119A
+          |
+          |YY336119B,
+          |YY336119A, unexpected value
+          |, YY336119A
+          |YY336119C,
+          |invalidformat
+          |""".stripMargin
+
+      val tempFile: Path = Files.createTempFile("test-upload", ".csv")
+      Files.write(tempFile, csvContent.getBytes("UTF-8"))
+
+      try {
+        val cvOptOutCsvDataList =
+          bulkUploadOptOutsService.readNinoBulkOptOutsFromFile(tempFile).futureValue
+
+        cvOptOutCsvDataList mustBe List(
+          Right("YY336119A"),
+          Right("YY336119B"),
+          Left("YY336119A, unexpected value"),
+          Left(", YY336119A"),
+          Right("YY336119C"),
+          Left("invalidformat")
+        )
+
+      } finally Files.deleteIfExists(tempFile)
+    }
+  }
+
+  "processBulkOptOuts" should {
+    "return an empty list when no ninos are passed" in {
+      val ninos = List()
+      val results: Seq[BulkOptOutResult] = bulkUploadOptOutsService.processBulkOptOuts(ninos).futureValue
+
+      results mustBe List.empty
+    }
+
+    "return informative results handling errors gracefully" in {
+      val ninos = List(
+        "nino1",
+        "nino2",
+        "nino3",
+        "nino4",
+        "nino5",
+        "nino6",
+        "nino7",
+        "nino8",
+        "nino9",
+        "nino10"
+      )
+
+      type PossibleOutCome = OptOutResult | Throwable
+
+      def createResult(possibleOutCome: PossibleOutCome): Future[OptOutResult] =
+        possibleOutCome match {
+          case optOutResult: OptOutResult => Future.successful(optOutResult)
+          case error: Throwable           => Future.failed(error)
+        }
+
+      when(mockEntityResolverConnector.optOut(TaxIdentifier.ninoIdentifier("nino1")))
+        .thenReturn(createResult(OptedOut))
+
+      when(mockEntityResolverConnector.optOut(TaxIdentifier.ninoIdentifier("nino2")))
+        .thenReturn(createResult(AlreadyOptedOut))
+
+      when(mockEntityResolverConnector.optOut(TaxIdentifier.ninoIdentifier("nino3")))
+        .thenReturn(createResult(AlreadyOptedOut))
+
+      when(mockEntityResolverConnector.optOut(TaxIdentifier.ninoIdentifier("nino4")))
+        .thenReturn(createResult(PreferenceNotFound))
+
+      when(mockEntityResolverConnector.optOut(TaxIdentifier.ninoIdentifier("nino5")))
+        .thenReturn(createResult(PreferenceNotFound))
+
+      when(mockEntityResolverConnector.optOut(TaxIdentifier.ninoIdentifier("nino6")))
+        .thenReturn(createResult(new RuntimeException("error1")))
+
+      when(mockEntityResolverConnector.optOut(TaxIdentifier.ninoIdentifier("nino7")))
+        .thenReturn(createResult(OptedOut))
+
+      when(mockEntityResolverConnector.optOut(TaxIdentifier.ninoIdentifier("nino8")))
+        .thenReturn(createResult(new RuntimeException("error2")))
+
+      when(mockEntityResolverConnector.optOut(TaxIdentifier.ninoIdentifier("nino9")))
+        .thenReturn(createResult(OptedOut))
+
+      when(mockEntityResolverConnector.optOut(TaxIdentifier.ninoIdentifier("nino10")))
+        .thenReturn(createResult(PreferenceNotFound))
+
+      val results: Seq[BulkOptOutResult] = bulkUploadOptOutsService.processBulkOptOuts(ninos).futureValue
+      results mustBe List(
+        ProcessedBulkOptOutResult("nino1", OptedOut),
+        ProcessedBulkOptOutResult("nino2", AlreadyOptedOut),
+        ProcessedBulkOptOutResult("nino3", AlreadyOptedOut),
+        ProcessedBulkOptOutResult("nino4", PreferenceNotFound),
+        ProcessedBulkOptOutResult("nino5", PreferenceNotFound),
+        FailedCallBulkOptOutResult("nino6"),
+        ProcessedBulkOptOutResult("nino7", OptedOut),
+        FailedCallBulkOptOutResult("nino8"),
+        ProcessedBulkOptOutResult("nino9", OptedOut),
+        ProcessedBulkOptOutResult("nino10", PreferenceNotFound)
+      )
+    }
+
+  }
+}

--- a/test/uk/gov/hmrc/preferencesadminfrontend/services/UploadServiceSpec.scala
+++ b/test/uk/gov/hmrc/preferencesadminfrontend/services/UploadServiceSpec.scala
@@ -27,6 +27,7 @@ import org.scalatestplus.play.PlaySpec
 import play.api.mvc.Results.{ BadRequest, InternalServerError, Ok }
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.preferencesadminfrontend.connectors.ChannelPreferencesConnector
+import uk.gov.hmrc.preferencesadminfrontend.services.model.*
 import uk.gov.hmrc.preferencesadminfrontend.services.model.csv.CsvData
 
 import java.nio.file.{ Files, Path }

--- a/test/uk/gov/hmrc/preferencesadminfrontend/services/model/TaxIdentifierSpec.scala
+++ b/test/uk/gov/hmrc/preferencesadminfrontend/services/model/TaxIdentifierSpec.scala
@@ -25,7 +25,7 @@ class TaxIdentifierSpec extends PlaySpec {
       val ex = intercept[RuntimeException] {
         TaxIdentifier("invalid", "123").regime
       }
-      ex.getMessage mustBe "Invalid tax id name"
+      ex.getMessage mustBe "Invalid tax id name 'invalid'"
     }
   }
 


### PR DESCRIPTION
"The following entries failed for unexpected reasons"

Can be from a record is in the entity-resolver api but not in the preferences api

<img width="892" height="812" alt="image" src="https://github.com/user-attachments/assets/0b7d3952-1d6c-413a-8244-de65fc161789" />

It should also tell you ones that have already been opted out.
