### PR TITLE
[DC-9199] - Enable Bulk Opt out option for Generic Role

### DIFF
--- a/app/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadBulkOptOutsController.scala
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadBulkOptOutsController.scala
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.preferencesadminfrontend.controllers
+
+import org.apache.pekko.actor.ActorSystem
+import play.api.Logging
+import play.api.i18n.I18nSupport
+import org.apache.pekko.stream.scaladsl.Framing
+import play.api.libs.Files
+import play.api.mvc.*
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import uk.gov.hmrc.preferencesadminfrontend.config.{ AppConfig, BulkOptOutsConfig }
+import uk.gov.hmrc.preferencesadminfrontend.services.BulkUploadOptOutsService
+import uk.gov.hmrc.preferencesadminfrontend.connectors.{ AlreadyOptedOut, OptedOut, PreferenceNotFound }
+import uk.gov.hmrc.preferencesadminfrontend.views.html.{ csv_upload_bulk_opt_confirmation, csv_upload_bulk_opt_outs }
+
+import javax.inject.{ Inject, Singleton }
+import scala.concurrent.{ ExecutionContext, Future }
+import uk.gov.hmrc.preferencesadminfrontend.services.{ BulkOptOutResult, FailedCallBulkOptOutResult, InvalidNinoBulkOptOutResult, ProcessedBulkOptOutResult }
+
+@Singleton
+class CsvUploadBulkOptOutsController @Inject() (
+  authorisedAction: AuthorisedAction,
+  csvUploadBulkOptOuts: csv_upload_bulk_opt_outs,
+  csvUploadBulkOptOutConfirmation: csv_upload_bulk_opt_confirmation,
+  bulkUploadOptOutsService: BulkUploadOptOutsService,
+  bulkOptOutsConfig: BulkOptOutsConfig,
+  mcc: MessagesControllerComponents
+)(implicit
+  appConfig: AppConfig,
+  ec: ExecutionContext,
+  actorSystem: ActorSystem
+) extends FrontendController(mcc) with I18nSupport with Logging with RoleAuthorisedAction(authorisedAction) {
+  override def role: Role = Role.Generic
+
+  val showBulkOptOutsUploadPage: Action[AnyContent] = authorisedAction { implicit request => _ =>
+    Future.successful(
+      Ok(
+        csvUploadBulkOptOuts(
+          maxUploads = bulkOptOutsConfig.maxUploadEntries,
+          errors = List.empty,
+          uploadedFileHadNoEntries = false,
+          uploadedFileWasInvalid = false,
+          tooManyEntriesWereUploadedCount = 0
+        )
+      )
+    )
+  }
+
+  def uploadBulkOptOuts(): Action[MultipartFormData[Files.TemporaryFile]] = Action.async(parse.multipartFormData) {
+    implicit request =>
+      request.body
+        .file("csvFile")
+        .map { filePart =>
+          val path = filePart.ref.path
+          val eventualErrorOrPotentialOptOuts = bulkUploadOptOutsService.readNinoBulkOptOutsFromFile(path)
+
+          eventualErrorOrPotentialOptOuts.flatMap {
+            case Left(framingException: Framing.FramingException) =>
+              logger.error("Failed uploading bulk opt outs file", framingException)
+
+              Future.successful(
+                Ok(
+                  csvUploadBulkOptOuts(
+                    maxUploads = bulkOptOutsConfig.maxUploadEntries,
+                    errors = List.empty,
+                    uploadedFileHadNoEntries = false,
+                    uploadedFileWasInvalid = true,
+                    tooManyEntriesWereUploadedCount = 0
+                  )
+                )
+              )
+            case Right(errorOrOptOutList) =>
+              processOptOutFileUpload(errorOrOptOutList)
+          }
+        }
+        .getOrElse {
+          Future.successful(
+            Ok(
+              csvUploadBulkOptOuts(
+                bulkOptOutsConfig.maxUploadEntries,
+                errors = List.empty,
+                uploadedFileHadNoEntries = true,
+                uploadedFileWasInvalid = false,
+                tooManyEntriesWereUploadedCount = 0
+              )
+            )
+          )
+        }
+  }
+
+  private def processOptOutFileUpload(
+    errorOrOptOutList: List[Either[String, String]]
+  )(implicit request: Request[_]): Future[Result] =
+    if (errorOrOptOutList.isEmpty) {
+      Future.successful(
+        Ok(
+          csvUploadBulkOptOuts(
+            maxUploads = bulkOptOutsConfig.maxUploadEntries,
+            errors = List.empty,
+            uploadedFileHadNoEntries = true,
+            uploadedFileWasInvalid = false,
+            tooManyEntriesWereUploadedCount = 0
+          )
+        )
+      )
+    } else {
+      val errors = errorOrOptOutList.collect { case Left(error) => error }
+      val successfulEntries = errorOrOptOutList.collect { case Right(success) => success }
+      val uploadedCount = errorOrOptOutList.length
+      val hasTooManyUploads = uploadedCount > bulkOptOutsConfig.maxUploadEntries
+
+      if (errors.nonEmpty || hasTooManyUploads) {
+        val tooManyEntriesWereUploadedCount = if (hasTooManyUploads) {
+          uploadedCount
+        } else {
+          0
+        }
+
+        Future.successful(
+          Ok(
+            csvUploadBulkOptOuts(
+              maxUploads = bulkOptOutsConfig.maxUploadEntries,
+              errors = errors,
+              uploadedFileHadNoEntries = false,
+              uploadedFileWasInvalid = false,
+              tooManyEntriesWereUploadedCount = tooManyEntriesWereUploadedCount
+            )
+          )
+        )
+      } else {
+        bulkUploadOptOutsService.processBulkOptOuts(successfulEntries).map { bulkOptOutResults =>
+          showBulkOptOutConfirmation(bulkOptOutResults)
+        }
+      }
+    }
+
+  private def showBulkOptOutConfirmation(
+    bulkOptOutResults: List[BulkOptOutResult]
+  )(implicit request: Request[_]): Result = {
+    val failedCallNinos = bulkOptOutResults.collect { case failedCall: FailedCallBulkOptOutResult =>
+      failedCall.nino
+    }
+    val successfullyOptedOutNinos =
+      bulkOptOutResults.collect { case ProcessedBulkOptOutResult(nino, OptedOut) => nino }
+
+    val invalidFormatNinos = bulkOptOutResults.collect { case InvalidNinoBulkOptOutResult(nino) => nino }
+
+    val alreadyOptedOutNinos =
+      bulkOptOutResults.collect { case ProcessedBulkOptOutResult(nino, AlreadyOptedOut) => nino }
+
+    val notFoundNinos = bulkOptOutResults.collect { case ProcessedBulkOptOutResult(nino, PreferenceNotFound) =>
+      nino
+    }
+
+    Ok(
+      csvUploadBulkOptOutConfirmation(
+        successfullyOptedOutNinos = successfullyOptedOutNinos,
+        invalidFormatNinos = invalidFormatNinos,
+        alreadyOptedOutNinos = alreadyOptedOutNinos,
+        notFoundNinos = notFoundNinos,
+        failedCallNinos = failedCallNinos
+      )
+    )
+  }
+
+}

--- a/app/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadController.scala
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadController.scala
@@ -17,14 +17,12 @@
 package uk.gov.hmrc.preferencesadminfrontend.controllers
 
 import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.scaladsl.Framing
 import play.api.Logging
 import play.api.i18n.I18nSupport
 import play.api.libs.Files
 import play.api.mvc.*
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
-import uk.gov.hmrc.preferencesadminfrontend.config.{ AppConfig, BulkOptOutsConfig }
-import uk.gov.hmrc.preferencesadminfrontend.connectors.{ AlreadyOptedOut, OptedOut, PreferenceNotFound }
+import uk.gov.hmrc.preferencesadminfrontend.config.AppConfig
 import uk.gov.hmrc.preferencesadminfrontend.services.*
 import uk.gov.hmrc.preferencesadminfrontend.views.html.*
 
@@ -35,16 +33,12 @@ class CsvUploadController @Inject() (
   authorisedAction: AuthorisedAction,
   csvUpload: csv_upload,
   csvUploadConfirm: csv_upload_confirmation,
-  csvUploadBulkOptOuts: csv_upload_bulk_opt_outs,
-  csvUploadBulkOptOutConfirmation: csv_upload_bulk_opt_confirmation,
   uploadService: UploadService,
-  bulkUploadOptOutsService: BulkUploadOptOutsService,
-  bulkOptOutsConfig: BulkOptOutsConfig,
   mcc: MessagesControllerComponents
 )(implicit appConfig: AppConfig, ec: ExecutionContext, actorSystem: ActorSystem)
     extends FrontendController(mcc) with I18nSupport with Logging with RoleAuthorisedAction(authorisedAction) {
 
-  override def role: Role = Role.Generic
+  override def role: Role = Role.Admin
 
   val showUploadPage: Action[AnyContent] = authorisedAction { implicit request => _ =>
     Future.successful(Ok(csvUpload()))
@@ -64,136 +58,5 @@ class CsvUploadController @Inject() (
         .getOrElse {
           Future.successful(BadRequest(csvUploadConfirm("File missing or incorrect data supplied!")))
         }
-  }
-
-  val showBulkOptOutsUploadPage: Action[AnyContent] = authorisedAction { implicit request => _ =>
-    Future.successful(
-      Ok(
-        csvUploadBulkOptOuts(
-          maxUploads = bulkOptOutsConfig.maxUploadEntries,
-          errors = List.empty,
-          uploadedFileHadNoEntries = false,
-          uploadedFileWasInvalid = false,
-          tooManyEntriesWereUploadedCount = 0
-        )
-      )
-    )
-  }
-
-  def uploadBulkOptOuts(): Action[MultipartFormData[Files.TemporaryFile]] = Action.async(parse.multipartFormData) {
-    implicit request =>
-      request.body
-        .file("csvFile")
-        .map { filePart =>
-          val path = filePart.ref.path
-          val eventualErrorOrPotentialOptOuts = bulkUploadOptOutsService.readNinoBulkOptOutsFromFile(path)
-
-          eventualErrorOrPotentialOptOuts.flatMap {
-            case Left(framingException: Framing.FramingException) =>
-              logger.error("Failed uploading bulk opt outs file", framingException)
-
-              Future.successful(
-                Ok(
-                  csvUploadBulkOptOuts(
-                    maxUploads = bulkOptOutsConfig.maxUploadEntries,
-                    errors = List.empty,
-                    uploadedFileHadNoEntries = false,
-                    uploadedFileWasInvalid = true,
-                    tooManyEntriesWereUploadedCount = 0
-                  )
-                )
-              )
-            case Right(errorOrOptOutList) =>
-              processOptOutFileUpload(errorOrOptOutList)
-          }
-        }
-        .getOrElse {
-          Future.successful(
-            Ok(
-              csvUploadBulkOptOuts(
-                bulkOptOutsConfig.maxUploadEntries,
-                errors = List.empty,
-                uploadedFileHadNoEntries = true,
-                uploadedFileWasInvalid = false,
-                tooManyEntriesWereUploadedCount = 0
-              )
-            )
-          )
-        }
-  }
-
-  private def processOptOutFileUpload(
-    errorOrOptOutList: List[Either[String, String]]
-  )(implicit request: Request[_]): Future[Result] =
-    if (errorOrOptOutList.isEmpty) {
-      Future.successful(
-        Ok(
-          csvUploadBulkOptOuts(
-            maxUploads = bulkOptOutsConfig.maxUploadEntries,
-            errors = List.empty,
-            uploadedFileHadNoEntries = true,
-            uploadedFileWasInvalid = false,
-            tooManyEntriesWereUploadedCount = 0
-          )
-        )
-      )
-    } else {
-      val errors = errorOrOptOutList.collect { case Left(error) => error }
-      val successfulEntries = errorOrOptOutList.collect { case Right(success) => success }
-      val uploadedCount = errorOrOptOutList.length
-      val hasTooManyUploads = uploadedCount > bulkOptOutsConfig.maxUploadEntries
-
-      if (errors.nonEmpty || hasTooManyUploads) {
-        val tooManyEntriesWereUploadedCount = if (hasTooManyUploads) {
-          uploadedCount
-        } else {
-          0
-        }
-
-        Future.successful(
-          Ok(
-            csvUploadBulkOptOuts(
-              maxUploads = bulkOptOutsConfig.maxUploadEntries,
-              errors = errors,
-              uploadedFileHadNoEntries = false,
-              uploadedFileWasInvalid = false,
-              tooManyEntriesWereUploadedCount = tooManyEntriesWereUploadedCount
-            )
-          )
-        )
-      } else {
-        bulkUploadOptOutsService.processBulkOptOuts(successfulEntries).map { bulkOptOutResults =>
-          showBulkOptOutConfirmation(bulkOptOutResults)
-        }
-      }
-    }
-
-  private def showBulkOptOutConfirmation(
-    bulkOptOutResults: List[BulkOptOutResult]
-  )(implicit request: Request[_]): Result = {
-    val failedCallNinos = bulkOptOutResults.collect { case failedCall: FailedCallBulkOptOutResult =>
-      failedCall.nino
-    }
-    val successfullyOptedOutNinos =
-      bulkOptOutResults.collect { case ProcessedBulkOptOutResult(nino, OptedOut) => nino }
-
-    val invalidFormatNinos = bulkOptOutResults.collect { case InvalidNinoBulkOptOutResult(nino) => nino }
-
-    val alreadyOptedOutNinos =
-      bulkOptOutResults.collect { case ProcessedBulkOptOutResult(nino, AlreadyOptedOut) => nino }
-
-    val notFoundNinos = bulkOptOutResults.collect { case ProcessedBulkOptOutResult(nino, PreferenceNotFound) =>
-      nino
-    }
-
-    Ok(
-      csvUploadBulkOptOutConfirmation(
-        successfullyOptedOutNinos = successfullyOptedOutNinos,
-        invalidFormatNinos = invalidFormatNinos,
-        alreadyOptedOutNinos = alreadyOptedOutNinos,
-        notFoundNinos = notFoundNinos,
-        failedCallNinos = failedCallNinos
-      )
-    )
   }
 }

--- a/app/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadController.scala
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadController.scala
@@ -44,7 +44,7 @@ class CsvUploadController @Inject() (
 )(implicit appConfig: AppConfig, ec: ExecutionContext, actorSystem: ActorSystem)
     extends FrontendController(mcc) with I18nSupport with Logging with RoleAuthorisedAction(authorisedAction) {
 
-  override def role: Role = Role.Admin
+  override def role: Role = Role.Generic
 
   val showUploadPage: Action[AnyContent] = authorisedAction { implicit request => _ =>
     Future.successful(Ok(csvUpload()))

--- a/app/uk/gov/hmrc/preferencesadminfrontend/controllers/LoginController.scala
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/controllers/LoginController.scala
@@ -63,7 +63,7 @@ class LoginController @Inject() (
         userData =>
           if (loginService.isAuthorised(userData)) {
             auditConnector.sendEvent(createLoginEvent(userData.username, true))
-            val sessionUpdated = updateSessionWithLoggedInUserRoleAndTimeStamp(request, userData)
+            val sessionUpdated = updateSessionParamByLoggedInUserRoleAndTimeStamp(request, userData)
 
             Future.successful(Redirect(routes.HomeController.showHomePage()).withSession(sessionUpdated))
           } else {
@@ -75,7 +75,7 @@ class LoginController @Inject() (
       )
   }
 
-  private def updateSessionWithLoggedInUserRoleAndTimeStamp(request: MessagesRequest[AnyContent], userData: User) =
+  private def updateSessionParamByLoggedInUserRoleAndTimeStamp(request: MessagesRequest[AnyContent], userData: User) =
     request.session
       + (User.sessionKey -> userData.username)
       + ("ts"            -> Instant.now.toEpochMilli.toString)

--- a/app/uk/gov/hmrc/preferencesadminfrontend/controllers/LoginController.scala
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/controllers/LoginController.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.play.audit.model.DataEvent
 import uk.gov.hmrc.play.bootstrap.config.AppName
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import uk.gov.hmrc.preferencesadminfrontend.config.AppConfig
-import uk.gov.hmrc.preferencesadminfrontend.controllers.Role.{ Admin, SolsGeneric }
+import uk.gov.hmrc.preferencesadminfrontend.controllers.Role.{ Admin, Generic, SolsGeneric }
 import uk.gov.hmrc.preferencesadminfrontend.controllers.model.User
 import uk.gov.hmrc.preferencesadminfrontend.services.LoginService
 import uk.gov.hmrc.preferencesadminfrontend.views.html.login
@@ -63,35 +63,40 @@ class LoginController @Inject() (
         userData =>
           if (loginService.isAuthorised(userData)) {
             auditConnector.sendEvent(createLoginEvent(userData.username, true))
-            val sessionUpdated =
-              request.session
-                + (User.sessionKey -> userData.username)
-                + ("ts"            -> Instant.now.toEpochMilli.toString)
-                + ("isAdmin"       -> loginService.hasRequiredRole(userData, Admin).toString)
-                + ("isSols"        -> loginService.hasRequiredRole(userData, SolsGeneric).toString)
+            val sessionUpdated = updateSessionWithLoggedInUserRoleAndTimeStamp(request, userData)
+
             Future.successful(Redirect(routes.HomeController.showHomePage()).withSession(sessionUpdated))
           } else {
             auditConnector.sendEvent(createLoginEvent(userData.username, false))
             val userFormWithErrors = userForm.fill(userData).withGlobalError("error.credentials.invalid")
+
             Future.successful(Unauthorized(loginView(userFormWithErrors)))
           }
       )
   }
 
-  def logoutAction() = authorisedAction.async { implicit request => user =>
+  private def updateSessionWithLoggedInUserRoleAndTimeStamp(request: MessagesRequest[AnyContent], userData: User) =
+    request.session
+      + (User.sessionKey -> userData.username)
+      + ("ts"            -> Instant.now.toEpochMilli.toString)
+      + ("isAdmin"       -> loginService.hasRequiredRole(userData, Admin).toString)
+      + ("isSols"        -> loginService.hasRequiredRole(userData, SolsGeneric).toString)
+      + ("isGeneric"     -> loginService.hasRequiredRole(userData, Generic).toString)
+
+  def logoutAction(): Action[AnyContent] = authorisedAction.async { implicit request => user =>
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
     auditConnector.sendEvent(createLogoutEvent(user.username))
     Future.successful(Redirect(routes.LoginController.showLoginPage()).withSession(Session()))
   }
 
-  def createLoginEvent(username: String, successful: Boolean) = DataEvent(
+  private def createLoginEvent(username: String, successful: Boolean): DataEvent = DataEvent(
     auditSource = AppName.fromConfiguration(config),
     auditType = if (successful) "TxSucceeded" else "TxFailed",
     detail = Map("user" -> username),
     tags = Map("transactionName" -> "Login")
   )
 
-  def createLogoutEvent(username: String) = DataEvent(
+  private def createLogoutEvent(username: String): DataEvent = DataEvent(
     auditSource = AppName.fromConfiguration(config),
     auditType = "TxSucceeded",
     detail = Map("user" -> username),

--- a/app/uk/gov/hmrc/preferencesadminfrontend/views/csv_upload_bulk_opt_outs.scala.html
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/views/csv_upload_bulk_opt_outs.scala.html
@@ -40,7 +40,7 @@
         )
     ))
     <h1 class="govuk-heading-l">Bulk Opt Out</h1>
-        @form(action = routes.CsvUploadController.uploadBulkOptOuts(), Symbol("enctype")-> "multipart/form-data") {
+        @form(action = routes.CsvUploadBulkOptOutsController.uploadBulkOptOuts(), Symbol("enctype")-> "multipart/form-data") {
             <div class="govuk-form-group">
                 <label class="govuk-heading-m" for="csv-upload">
                     Upload a CSV file For Bulk Opt Outs (Maximum @maxUploads Ninos)

--- a/app/uk/gov/hmrc/preferencesadminfrontend/views/home.scala.html
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/views/home.scala.html
@@ -37,24 +37,27 @@
                 <a class="govuk-link govuk-task-list__link" href="/paperless/admin/search">Paperless Admin</a>
             </li>
             @if(TemplateHelper.validateRole(request.session, "isAdmin")) {
-            <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                <a class="govuk-link govuk-task-list__link" href="/paperless/admin/message-brake">Message Brake</a>
-            </li>
-            <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                <a class="govuk-link govuk-task-list__link" href="/paperless/admin/allowlist">Message Brake Allowlist</a>
-            </li>
-            <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                <a class="govuk-link govuk-task-list__link" href="/paperless/admin/decode">Message Decode</a>
-            </li>
-            <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                <a class="govuk-link govuk-task-list__link" href="/paperless/admin/multi-search">Multi Search</a>
-            </li>
-            <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                <a class="govuk-link govuk-task-list__link" href="/paperless/admin/csv-upload">File Upload Id Updates</a>
-            </li>
-            <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                <a class="govuk-link govuk-task-list__link" href="/paperless/admin/csv-upload-bulk-opt-outs">Bulk Opt Out</a>
-            </li>
+                <li class="govuk-task-list__item govuk-task-list__item--with-link">
+                    <a class="govuk-link govuk-task-list__link" href="/paperless/admin/message-brake">Message Brake</a>
+                </li>
+                <li class="govuk-task-list__item govuk-task-list__item--with-link">
+                    <a class="govuk-link govuk-task-list__link" href="/paperless/admin/allowlist">Message Brake Allowlist</a>
+                </li>
+                <li class="govuk-task-list__item govuk-task-list__item--with-link">
+                    <a class="govuk-link govuk-task-list__link" href="/paperless/admin/decode">Message Decode</a>
+                </li>
+                <li class="govuk-task-list__item govuk-task-list__item--with-link">
+                    <a class="govuk-link govuk-task-list__link" href="/paperless/admin/multi-search">Multi Search</a>
+                </li>
+                <li class="govuk-task-list__item govuk-task-list__item--with-link">
+                    <a class="govuk-link govuk-task-list__link" href="/paperless/admin/csv-upload">File Upload Id Updates</a>
+                </li>
+            }
+
+            @if(TemplateHelper.validateRole(request.session, "isAdmin") || TemplateHelper.validateRole(request.session, "isGeneric")) {
+                <li class="govuk-task-list__item govuk-task-list__item--with-link">
+                    <a class="govuk-link govuk-task-list__link" href="/paperless/admin/csv-upload-bulk-opt-outs">Bulk Opt Out</a>
+                </li>
             }
         </ul>
     </div>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -26,8 +26,8 @@ POST        /message-brake/approve/confirmation         uk.gov.hmrc.preferencesa
 POST        /message-brake/reject/confirmation          uk.gov.hmrc.preferencesadminfrontend.controllers.MessageBrakeController.confirmRejectBatch()
 GET         /csv-upload                                 uk.gov.hmrc.preferencesadminfrontend.controllers.CsvUploadController.showUploadPage()
 POST        /csv-upload/confirmation                    uk.gov.hmrc.preferencesadminfrontend.controllers.CsvUploadController.upload()
-GET         /csv-upload-bulk-opt-outs                   uk.gov.hmrc.preferencesadminfrontend.controllers.CsvUploadController.showBulkOptOutsUploadPage
-POST        /csv-upload-bulk-opt-outs/confirmation      uk.gov.hmrc.preferencesadminfrontend.controllers.CsvUploadController.uploadBulkOptOuts()
+GET         /csv-upload-bulk-opt-outs                   uk.gov.hmrc.preferencesadminfrontend.controllers.CsvUploadBulkOptOutsController.showBulkOptOutsUploadPage
+POST        /csv-upload-bulk-opt-outs/confirmation      uk.gov.hmrc.preferencesadminfrontend.controllers.CsvUploadBulkOptOutsController.uploadBulkOptOuts()
 
 
 # Temporaty endpoits to migrate MDTP to ETMP

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -53,6 +53,16 @@ users = [
       username = "solsUser"
       password = "cHdk"
       roles = "sols, generic"
+    },
+    {
+      username = "solsOnlyUser"
+      password = "cHdk"
+      roles = "sols"
+    },
+    {
+      username = "genericUser"
+      password = "cHdk"
+      roles = "generic"
     }
 ]
 

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,6 +1,6 @@
 <scalastyle>
  <name>Scalastyle standard configuration</name>
- <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"/>
  <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
   <parameters>
    <parameter name="maxFileLength"><![CDATA[800]]></parameter>
@@ -25,9 +25,9 @@
  */]]></parameter>
   </parameters>
  </check>
- <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"/>
  <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
   <parameters>
    <parameter name="maxLineLength"><![CDATA[160]]></parameter>
@@ -49,7 +49,7 @@
    <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
   </parameters>
  </check>
- <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"/>
  <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
   <parameters>
    <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
@@ -65,14 +65,14 @@
    <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
   </parameters>
  </check>
- <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"/>
  <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
   <parameters>
    <parameter name="regex"><![CDATA[println]]></parameter>
@@ -88,8 +88,8 @@
    <parameter name="maximum"><![CDATA[10]]></parameter>
   </parameters>
  </check>
- <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"/>
  <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
   <parameters>
    <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
@@ -111,7 +111,7 @@
    <parameter name="maxMethods"><![CDATA[30]]></parameter>
   </parameters>
  </check>
- <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+ <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"/>
 </scalastyle>

--- a/test/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadBulkOptOutsControllerSpec.scala
+++ b/test/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadBulkOptOutsControllerSpec.scala
@@ -1,0 +1,453 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.preferencesadminfrontend.controllers
+
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Framing.FramingException
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.*
+import org.mockito.Mockito.*
+import org.scalactic.source.Position
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import org.scalatestplus.play.{ HtmlUnitFactory, PlaySpec }
+import play.api.http.*
+import play.api.i18n.MessagesApi
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.Files.TemporaryFile
+import play.api.mvc.MultipartFormData.FilePart
+import play.api.mvc.{ MultipartFormData, Result }
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import play.api.{ Application, inject }
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.preferencesadminfrontend.connectors.{ AlreadyOptedOut, OptedOut, PreferenceNotFound }
+import uk.gov.hmrc.preferencesadminfrontend.controllers.model.User
+import uk.gov.hmrc.preferencesadminfrontend.services.*
+import uk.gov.hmrc.preferencesadminfrontend.utils.SpecBase
+
+import java.nio.file.Path
+import scala.concurrent.{ ExecutionContext, Future }
+
+class CsvUploadBulkOptOutsControllerSpec
+    extends PlaySpec with GuiceOneAppPerSuite with SpecBase with ScalaFutures with MockitoSugar with HtmlUnitFactory {
+
+  implicit lazy val materializer: Materializer = app.materializer
+  override implicit lazy val app: Application = GuiceApplicationBuilder().build()
+  implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+
+  val emptyString = ""
+
+  "showBulkOptOutsUploadPage (GET /csv-upload-bulk-opt-outs)" should {
+    "return HTML" in new TestCase {
+      val result: Future[Result] =
+        controller.showBulkOptOutsUploadPage()(
+          FakeRequest(emptyString, emptyString).withSession(User.sessionKey -> "genericUser")
+        )
+
+      contentType(result) mustBe Some("text/html")
+      charset(result) mustBe Some("utf-8")
+      status(result) mustBe OK
+
+      extractBulkOptOutErrors(contentAsString(result)) mustBe List.empty
+    }
+
+    "redirect to login page for non-admin user" in new TestCase {
+      val result: Future[Result] =
+        controller.showBulkOptOutsUploadPage()(FakeRequest("GET", "/decode"))
+      status(result) mustBe Status.SEE_OTHER
+
+    }
+  }
+
+  def extractBulkOptOutErrors(body: String): List[String] = {
+    val possibleErrorMessages = List(
+      "The following uploaded entries were in an invalid Nino format",
+      "The following uploaded entries were not fully opted in",
+      "The following uploaded entries were not found",
+      "The following uploaded entries were invalid",
+      "The following entries failed for unexpected reasons",
+      "The uploaded file had no entries",
+      "Too many entries were uploaded",
+      "Invalid File Format. The uploaded file format could not be processed. Please enter a valid .csv file format."
+    )
+
+    possibleErrorMessages.collect {
+      case possibleError if body.contains(possibleError) =>
+        possibleError
+    }
+  }
+
+  "uploadBulkOptOuts (POST /csv-upload-bulk-opt-outs/confirmation)" should {
+    def filePart: FilePart[TemporaryFile] = FilePart(
+      key = "csvFile",
+      filename = "test.csv",
+      contentType = Some("text/csv"),
+      ref = mock[TemporaryFile]
+    )
+
+    "return 400 when form binding fails" in new TestCase {
+      val request = FakeRequest(emptyString, emptyString)
+        .withSession(User.sessionKey -> "admin")
+
+      val result = controller.uploadBulkOptOuts()(request)
+
+      status(result) mustBe BAD_REQUEST
+    }
+
+    "return 200 but display a message saying the file could not be processed when it fails processing" in new TestCase {
+      val mockTemporaryFile = mock[TemporaryFile]
+      val mockPath = mock[Path]
+
+      when(mockTemporaryFile.path).thenReturn(mockPath)
+
+      when(mockBulkOptOutsService.readNinoBulkOptOutsFromFile(any())(any()))
+        .thenReturn(
+          Future.successful(
+            Left(
+              new FramingException("failed reading file")
+            )
+          )
+        )
+
+      val formData = MultipartFormData[TemporaryFile](
+        dataParts = Map.empty,
+        files = Seq(filePart),
+        badParts = Seq.empty
+      )
+
+      val request = FakeRequest(emptyString, emptyString)
+        .withSession(User.sessionKey -> "admin")
+        .withBody(formData)
+
+      val result = controller.uploadBulkOptOuts()(request)
+
+      status(result) mustBe OK
+      val body: String = contentAsString(result)
+
+      extractBulkOptOutErrors(body) mustBe List(
+        "Invalid File Format. The uploaded file format could not be processed. Please enter a valid .csv file format."
+      )
+    }
+
+    "return 200 but display errors when some could not be validated" in new TestCase {
+      val mockTemporaryFile = mock[TemporaryFile]
+      val mockPath = mock[Path]
+
+      when(mockTemporaryFile.path).thenReturn(mockPath)
+
+      when(mockBulkOptOutsService.readNinoBulkOptOutsFromFile(any())(any()))
+        .thenReturn(
+          Future.successful(
+            Right(
+              List(
+                Right("nino1"),
+                Left("error1,sss"),
+                Right("nino2"),
+                Left("error2,sss")
+              )
+            )
+          )
+        )
+
+      val formData = MultipartFormData[TemporaryFile](
+        dataParts = Map.empty,
+        files = Seq(filePart),
+        badParts = Seq.empty
+      )
+
+      val request = FakeRequest(emptyString, emptyString)
+        .withSession(User.sessionKey -> "admin")
+        .withBody(formData)
+
+      val result = controller.uploadBulkOptOuts()(request)
+
+      status(result) mustBe OK
+      val body: String = contentAsString(result)
+
+      extractBulkOptOutErrors(body) mustBe List(
+        "The following uploaded entries were invalid"
+      )
+
+      body must include("error1,sss")
+      body must include("error2,sss")
+
+      body must not include "nino1"
+      body must not include "nino2"
+
+    }
+
+    "return 200 but display no entries were found if file was empty" in new TestCase {
+      val mockTemporaryFile = mock[TemporaryFile]
+      val mockPath = mock[Path]
+
+      when(mockTemporaryFile.path).thenReturn(mockPath)
+
+      when(mockBulkOptOutsService.readNinoBulkOptOutsFromFile(any())(any()))
+        .thenReturn(
+          Future.successful(Right(List.empty))
+        )
+
+      val formData = MultipartFormData[TemporaryFile](
+        dataParts = Map.empty,
+        files = Seq(filePart),
+        badParts = Seq.empty
+      )
+
+      val request = FakeRequest(emptyString, emptyString)
+        .withSession(User.sessionKey -> "admin")
+        .withBody(formData)
+
+      val result = controller.uploadBulkOptOuts()(request)
+
+      status(result) mustBe OK
+      val body: String = contentAsString(result)
+
+      extractBulkOptOutErrors(body) mustBe List(
+        "The uploaded file had no entries"
+      )
+    }
+
+    "return 200 but display too many entries if the limit is exceeded" in new TestCase {
+      val mockTemporaryFile = mock[TemporaryFile]
+      val mockPath = mock[Path]
+
+      val ninos = (1 to 101).map { index =>
+        s"nino-$index"
+      }.toList
+
+      when(mockTemporaryFile.path).thenReturn(mockPath)
+
+      when(mockBulkOptOutsService.readNinoBulkOptOutsFromFile(any())(any()))
+        .thenReturn(
+          Future.successful(Right(ninos.map(Right.apply)))
+        )
+
+      val formData = MultipartFormData[TemporaryFile](
+        dataParts = Map.empty,
+        files = Seq(filePart),
+        badParts = Seq.empty
+      )
+
+      val request = FakeRequest(emptyString, emptyString)
+        .withSession(User.sessionKey -> "admin")
+        .withBody(formData)
+
+      val result = controller.uploadBulkOptOuts()(request)
+
+      status(result) mustBe OK
+      val body: String = contentAsString(result)
+
+      extractBulkOptOutErrors(body) mustBe List(
+        "Too many entries were uploaded"
+      )
+    }
+
+    def testValidParsing(
+      controller: CsvUploadBulkOptOutsController,
+      mockBulkOptOutsService: BulkUploadOptOutsService,
+      ninos: List[String],
+      serverResponse: List[BulkOptOutResult],
+      expectedErrors: List[String],
+      successCount: Int
+    )(implicit position: Position): Unit = {
+      val mockTemporaryFile = mock[TemporaryFile]
+      val mockPath = mock[Path]
+
+      when(mockTemporaryFile.path).thenReturn(mockPath)
+
+      val formData = MultipartFormData[TemporaryFile](
+        dataParts = Map.empty,
+        files = Seq(filePart),
+        badParts = Seq.empty
+      )
+
+      when(mockBulkOptOutsService.readNinoBulkOptOutsFromFile(any())(any()))
+        .thenReturn(
+          Future.successful(
+            Right(ninos.map(Right.apply))
+          )
+        )
+
+      when(mockBulkOptOutsService.processBulkOptOuts(ArgumentMatchers.eq(ninos))(any(), any(), any()))
+        .thenReturn(
+          Future.successful(
+            serverResponse
+          )
+        )
+
+      val request = FakeRequest(emptyString, emptyString)
+        .withSession(User.sessionKey -> "admin")
+        .withBody(formData)
+
+      val result = controller.uploadBulkOptOuts()(request)
+
+      status(result) mustBe OK
+      val body: String = contentAsString(result)
+
+      extractBulkOptOutErrors(body) mustBe expectedErrors
+      body must include(s"Successfully opted out $successCount records")
+    }
+
+    "return 200 when only valid entries that were at maximum upload count were parsed and processed successfully as opted out" in new TestCase {
+      val ninos = (1 to 100).map { index =>
+        s"nino-$index"
+      }.toList
+
+      testValidParsing(
+        controller = controller,
+        mockBulkOptOutsService = mockBulkOptOutsService,
+        ninos = ninos,
+        serverResponse = ninos.map(nino => ProcessedBulkOptOutResult(nino, OptedOut)),
+        expectedErrors = List.empty,
+        successCount = ninos.size
+      )
+    }
+
+    "return 200 when only valid entries were parsed but were already opted out" in new TestCase {
+      val ninos = List(
+        "nino1",
+        "nino2"
+      )
+
+      testValidParsing(
+        controller = controller,
+        mockBulkOptOutsService = mockBulkOptOutsService,
+        ninos = ninos,
+        serverResponse = List(
+          ProcessedBulkOptOutResult("nino1", AlreadyOptedOut),
+          ProcessedBulkOptOutResult("nino2", AlreadyOptedOut)
+        ),
+        expectedErrors = List("The following uploaded entries were not fully opted in"),
+        successCount = 0
+      )
+    }
+
+    "return 200 when only valid entries were parsed but were not found" in new TestCase {
+      val ninos = List(
+        "nino1",
+        "nino2"
+      )
+
+      testValidParsing(
+        controller = controller,
+        mockBulkOptOutsService = mockBulkOptOutsService,
+        ninos = ninos,
+        serverResponse = List(
+          ProcessedBulkOptOutResult("nino1", PreferenceNotFound),
+          ProcessedBulkOptOutResult("nino2", PreferenceNotFound)
+        ),
+        expectedErrors = List("The following uploaded entries were not found"),
+        successCount = 0
+      )
+    }
+
+    "return 200 when only valid entries were parsed but failed for unknown reasons" in new TestCase {
+      val ninos = List(
+        "nino1",
+        "nino2"
+      )
+
+      testValidParsing(
+        controller = controller,
+        mockBulkOptOutsService = mockBulkOptOutsService,
+        ninos = ninos,
+        serverResponse = List(
+          FailedCallBulkOptOutResult("nino1"),
+          FailedCallBulkOptOutResult("nino2")
+        ),
+        expectedErrors = List("The following entries failed for unexpected reasons"),
+        successCount = 0
+      )
+    }
+
+    "return 200 when only valid entries were parsed but failed due to an invalid formatted Nino value" in new TestCase {
+      val ninos = List(
+        "nino1",
+        "nino2"
+      )
+
+      testValidParsing(
+        controller = controller,
+        mockBulkOptOutsService = mockBulkOptOutsService,
+        ninos = ninos,
+        serverResponse = List(
+          InvalidNinoBulkOptOutResult("nino1"),
+          InvalidNinoBulkOptOutResult("nino2")
+        ),
+        expectedErrors = List("The following uploaded entries were in an invalid Nino format"),
+        successCount = 0
+      )
+    }
+
+    "return 200 and display all combinations of reponses" in new TestCase {
+      val ninos = List(
+        "nino1",
+        "nino2",
+        "nino3",
+        "nino4",
+        "nino5",
+        "nino6",
+        "nino7",
+        "nino8",
+        "nino9"
+      )
+
+      testValidParsing(
+        controller = controller,
+        mockBulkOptOutsService = mockBulkOptOutsService,
+        ninos = ninos,
+        serverResponse = List(
+          ProcessedBulkOptOutResult("nino1", PreferenceNotFound),
+          ProcessedBulkOptOutResult("nino2", OptedOut),
+          FailedCallBulkOptOutResult("nino3"),
+          FailedCallBulkOptOutResult("nino3"),
+          FailedCallBulkOptOutResult("nino4"),
+          ProcessedBulkOptOutResult("nino5", AlreadyOptedOut),
+          ProcessedBulkOptOutResult("nino6", AlreadyOptedOut),
+          ProcessedBulkOptOutResult("nino7", OptedOut),
+          ProcessedBulkOptOutResult("nino8", OptedOut),
+          InvalidNinoBulkOptOutResult("nino9")
+        ),
+        expectedErrors = List(
+          "The following uploaded entries were in an invalid Nino format",
+          "The following uploaded entries were not fully opted in",
+          "The following uploaded entries were not found",
+          "The following entries failed for unexpected reasons"
+        ),
+        successCount = 3
+      )
+    }
+  }
+
+  class TestCase {
+    lazy val mockBulkOptOutsService: BulkUploadOptOutsService = mock[BulkUploadOptOutsService]
+
+    implicit lazy val app: Application = GuiceApplicationBuilder()
+      .overrides(inject.bind[BulkUploadOptOutsService].toInstance(mockBulkOptOutsService))
+      .build()
+
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+    implicit lazy val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
+    implicit lazy val materializer: Materializer = app.materializer
+    implicit lazy val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+
+    lazy val controller: CsvUploadBulkOptOutsController = app.injector.instanceOf[CsvUploadBulkOptOutsController]
+  }
+
+}

--- a/test/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadControllerSpec.scala
+++ b/test/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadControllerSpec.scala
@@ -54,20 +54,20 @@ class CsvUploadControllerSpec
   "showUploadPage (GET /csv-upload)" should {
     "return 200" in new TestCase {
       val result: Future[Result] =
-        controller.showUploadPage()(FakeRequest("GET", "/decode").withSession(User.sessionKey -> "admin"))
+        controller.showUploadPage()(FakeRequest("GET", "/decode").withSession(User.sessionKey -> "genericUser"))
       status(result) mustBe Status.OK
     }
 
     "return HTML" in new TestCase {
       val result: Future[Result] =
-        controller.showUploadPage()(FakeRequest("GET", "/decode").withSession(User.sessionKey -> "admin"))
+        controller.showUploadPage()(FakeRequest("GET", "/decode").withSession(User.sessionKey -> "genericUser"))
       contentType(result) mustBe Some("text/html")
       charset(result) mustBe Some("utf-8")
     }
 
-    "redirect to login page for non-admin user" in new TestCase {
+    "redirect to login page for sols user" in new TestCase {
       val result: Future[Result] =
-        controller.showUploadPage()(FakeRequest("GET", "/decode").withSession(User.sessionKey -> "user"))
+        controller.showUploadPage()(FakeRequest("GET", "/decode").withSession(User.sessionKey -> "solsOnlyUser"))
       status(result) mustBe Status.SEE_OTHER
     }
   }
@@ -119,7 +119,7 @@ class CsvUploadControllerSpec
   "showBulkOptOutsUploadPage (GET /csv-upload-bulk-opt-outs)" should {
     "return HTML" in new TestCase {
       val result: Future[Result] =
-        controller.showBulkOptOutsUploadPage()(FakeRequest("", "").withSession(User.sessionKey -> "admin"))
+        controller.showBulkOptOutsUploadPage()(FakeRequest("", "").withSession(User.sessionKey -> "genericUser"))
 
       contentType(result) mustBe Some("text/html")
       charset(result) mustBe Some("utf-8")

--- a/test/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadControllerSpec.scala
+++ b/test/uk/gov/hmrc/preferencesadminfrontend/controllers/CsvUploadControllerSpec.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.preferencesadminfrontend.controllers
 
 import org.apache.pekko.stream.Materializer
-import org.apache.pekko.stream.scaladsl.Framing.FramingException
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.*
 import org.mockito.Mockito.*
@@ -36,7 +35,6 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import play.api.{ Application, inject }
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.preferencesadminfrontend.connectors.{ AlreadyOptedOut, OptedOut, PreferenceNotFound }
 import uk.gov.hmrc.preferencesadminfrontend.controllers.model.User
 import uk.gov.hmrc.preferencesadminfrontend.services.*
 import uk.gov.hmrc.preferencesadminfrontend.utils.SpecBase
@@ -54,20 +52,20 @@ class CsvUploadControllerSpec
   "showUploadPage (GET /csv-upload)" should {
     "return 200" in new TestCase {
       val result: Future[Result] =
-        controller.showUploadPage()(FakeRequest("GET", "/decode").withSession(User.sessionKey -> "genericUser"))
+        controller.showUploadPage()(FakeRequest("GET", "/decode").withSession(User.sessionKey -> "admin"))
       status(result) mustBe Status.OK
     }
 
     "return HTML" in new TestCase {
       val result: Future[Result] =
-        controller.showUploadPage()(FakeRequest("GET", "/decode").withSession(User.sessionKey -> "genericUser"))
+        controller.showUploadPage()(FakeRequest("GET", "/decode").withSession(User.sessionKey -> "admin"))
       contentType(result) mustBe Some("text/html")
       charset(result) mustBe Some("utf-8")
     }
 
-    "redirect to login page for sols user" in new TestCase {
+    "redirect to login page for non-admin user" in new TestCase {
       val result: Future[Result] =
-        controller.showUploadPage()(FakeRequest("GET", "/decode").withSession(User.sessionKey -> "solsOnlyUser"))
+        controller.showUploadPage()(FakeRequest("GET", "/decode").withSession(User.sessionKey -> "user"))
       status(result) mustBe Status.SEE_OTHER
     }
   }
@@ -83,8 +81,8 @@ class CsvUploadControllerSpec
     }
 
     "return 200 when service returns nil" in new TestCase {
-      val mockTemporaryFile = mock[TemporaryFile]
-      val mockPath = mock[Path]
+      val mockTemporaryFile: TemporaryFile = mock[TemporaryFile]
+      val mockPath: Path = mock[Path]
 
       when(mockTemporaryFile.path).thenReturn(mockPath)
 
@@ -116,394 +114,11 @@ class CsvUploadControllerSpec
     }
   }
 
-  "showBulkOptOutsUploadPage (GET /csv-upload-bulk-opt-outs)" should {
-    "return HTML" in new TestCase {
-      val result: Future[Result] =
-        controller.showBulkOptOutsUploadPage()(FakeRequest("", "").withSession(User.sessionKey -> "genericUser"))
-
-      contentType(result) mustBe Some("text/html")
-      charset(result) mustBe Some("utf-8")
-      status(result) mustBe OK
-
-      extractBulkOptOutErrors(contentAsString(result)) mustBe List.empty
-    }
-
-    "redirect to login page for non-admin user" in new TestCase {
-      val result: Future[Result] =
-        controller.showBulkOptOutsUploadPage()(FakeRequest("GET", "/decode"))
-      status(result) mustBe Status.SEE_OTHER
-
-    }
-  }
-
-  def extractBulkOptOutErrors(body: String): List[String] = {
-    val possibleErrorMessages = List(
-      "The following uploaded entries were in an invalid Nino format",
-      "The following uploaded entries were not fully opted in",
-      "The following uploaded entries were not found",
-      "The following uploaded entries were invalid",
-      "The following entries failed for unexpected reasons",
-      "The uploaded file had no entries",
-      "Too many entries were uploaded",
-      "Invalid File Format. The uploaded file format could not be processed. Please enter a valid .csv file format."
-    )
-
-    possibleErrorMessages.collect {
-      case possibleError if body.contains(possibleError) =>
-        possibleError
-    }
-  }
-
-  "uploadBulkOptOuts (POST /csv-upload-bulk-opt-outs/confirmation)" should {
-    def filePart: FilePart[TemporaryFile] = FilePart(
-      key = "csvFile",
-      filename = "test.csv",
-      contentType = Some("text/csv"),
-      ref = mock[TemporaryFile]
-    )
-
-    "return 400 when form binding fails" in new TestCase {
-      val request = FakeRequest("", "")
-        .withSession(User.sessionKey -> "admin")
-
-      val result = controller.uploadBulkOptOuts()(request)
-
-      status(result) mustBe BAD_REQUEST
-    }
-
-    "return 200 but display a message saying the file could not be processed when it fails processing" in new TestCase {
-      val mockTemporaryFile = mock[TemporaryFile]
-      val mockPath = mock[Path]
-
-      when(mockTemporaryFile.path).thenReturn(mockPath)
-
-      when(mockBulkOptOutsService.readNinoBulkOptOutsFromFile(any())(any()))
-        .thenReturn(
-          Future.successful(
-            Left(
-              new FramingException("failed reading file")
-            )
-          )
-        )
-
-      val formData = MultipartFormData[TemporaryFile](
-        dataParts = Map.empty,
-        files = Seq(filePart),
-        badParts = Seq.empty
-      )
-
-      val request = FakeRequest("", "")
-        .withSession(User.sessionKey -> "admin")
-        .withBody(formData)
-
-      val result = controller.uploadBulkOptOuts()(request)
-
-      status(result) mustBe OK
-      val body: String = contentAsString(result)
-
-      extractBulkOptOutErrors(body) mustBe List(
-        "Invalid File Format. The uploaded file format could not be processed. Please enter a valid .csv file format."
-      )
-    }
-
-    "return 200 but display errors when some could not be validated" in new TestCase {
-      val mockTemporaryFile = mock[TemporaryFile]
-      val mockPath = mock[Path]
-
-      when(mockTemporaryFile.path).thenReturn(mockPath)
-
-      when(mockBulkOptOutsService.readNinoBulkOptOutsFromFile(any())(any()))
-        .thenReturn(
-          Future.successful(
-            Right(
-              List(
-                Right("nino1"),
-                Left("error1,sss"),
-                Right("nino2"),
-                Left("error2,sss")
-              )
-            )
-          )
-        )
-
-      val formData = MultipartFormData[TemporaryFile](
-        dataParts = Map.empty,
-        files = Seq(filePart),
-        badParts = Seq.empty
-      )
-
-      val request = FakeRequest("", "")
-        .withSession(User.sessionKey -> "admin")
-        .withBody(formData)
-
-      val result = controller.uploadBulkOptOuts()(request)
-
-      status(result) mustBe OK
-      val body: String = contentAsString(result)
-
-      extractBulkOptOutErrors(body) mustBe List(
-        "The following uploaded entries were invalid"
-      )
-
-      body must include("error1,sss")
-      body must include("error2,sss")
-
-      body must not include "nino1"
-      body must not include "nino2"
-
-    }
-
-    "return 200 but display no entries were found if file was empty" in new TestCase {
-      val mockTemporaryFile = mock[TemporaryFile]
-      val mockPath = mock[Path]
-
-      when(mockTemporaryFile.path).thenReturn(mockPath)
-
-      when(mockBulkOptOutsService.readNinoBulkOptOutsFromFile(any())(any()))
-        .thenReturn(
-          Future.successful(Right(List.empty))
-        )
-
-      val formData = MultipartFormData[TemporaryFile](
-        dataParts = Map.empty,
-        files = Seq(filePart),
-        badParts = Seq.empty
-      )
-
-      val request = FakeRequest("", "")
-        .withSession(User.sessionKey -> "admin")
-        .withBody(formData)
-
-      val result = controller.uploadBulkOptOuts()(request)
-
-      status(result) mustBe OK
-      val body: String = contentAsString(result)
-
-      extractBulkOptOutErrors(body) mustBe List(
-        "The uploaded file had no entries"
-      )
-    }
-
-    "return 200 but display too many entries if the limit is exceeded" in new TestCase {
-      val mockTemporaryFile = mock[TemporaryFile]
-      val mockPath = mock[Path]
-
-      val ninos = (1 to 101).map { index =>
-        s"nino-$index"
-      }.toList
-
-      when(mockTemporaryFile.path).thenReturn(mockPath)
-
-      when(mockBulkOptOutsService.readNinoBulkOptOutsFromFile(any())(any()))
-        .thenReturn(
-          Future.successful(Right(ninos.map(Right.apply)))
-        )
-
-      val formData = MultipartFormData[TemporaryFile](
-        dataParts = Map.empty,
-        files = Seq(filePart),
-        badParts = Seq.empty
-      )
-
-      val request = FakeRequest("", "")
-        .withSession(User.sessionKey -> "admin")
-        .withBody(formData)
-
-      val result = controller.uploadBulkOptOuts()(request)
-
-      status(result) mustBe OK
-      val body: String = contentAsString(result)
-
-      extractBulkOptOutErrors(body) mustBe List(
-        "Too many entries were uploaded"
-      )
-    }
-
-    def testValidParsing(
-      controller: CsvUploadController,
-      mockBulkOptOutsService: BulkUploadOptOutsService,
-      ninos: List[String],
-      serverResponse: List[BulkOptOutResult],
-      expectedErrors: List[String],
-      successCount: Int
-    )(implicit position: Position): Unit = {
-      val mockTemporaryFile = mock[TemporaryFile]
-      val mockPath = mock[Path]
-
-      when(mockTemporaryFile.path).thenReturn(mockPath)
-
-      val formData = MultipartFormData[TemporaryFile](
-        dataParts = Map.empty,
-        files = Seq(filePart),
-        badParts = Seq.empty
-      )
-
-      when(mockBulkOptOutsService.readNinoBulkOptOutsFromFile(any())(any()))
-        .thenReturn(
-          Future.successful(
-            Right(ninos.map(Right.apply))
-          )
-        )
-
-      when(mockBulkOptOutsService.processBulkOptOuts(ArgumentMatchers.eq(ninos))(any(), any(), any()))
-        .thenReturn(
-          Future.successful(
-            serverResponse
-          )
-        )
-
-      val request = FakeRequest("", "")
-        .withSession(User.sessionKey -> "admin")
-        .withBody(formData)
-
-      val result = controller.uploadBulkOptOuts()(request)
-
-      status(result) mustBe OK
-      val body: String = contentAsString(result)
-
-      extractBulkOptOutErrors(body) mustBe expectedErrors
-      body must include(s"Successfully opted out $successCount records")
-    }
-
-    "return 200 when only valid entries that were at maximum upload count were parsed and processed successfully as opted out" in new TestCase {
-      val ninos = (1 to 100).map { index =>
-        s"nino-$index"
-      }.toList
-
-      testValidParsing(
-        controller = controller,
-        mockBulkOptOutsService = mockBulkOptOutsService,
-        ninos = ninos,
-        serverResponse = ninos.map(nino => ProcessedBulkOptOutResult(nino, OptedOut)),
-        expectedErrors = List.empty,
-        successCount = ninos.size
-      )
-    }
-
-    "return 200 when only valid entries were parsed but were already opted out" in new TestCase {
-      val ninos = List(
-        "nino1",
-        "nino2"
-      )
-
-      testValidParsing(
-        controller = controller,
-        mockBulkOptOutsService = mockBulkOptOutsService,
-        ninos = ninos,
-        serverResponse = List(
-          ProcessedBulkOptOutResult("nino1", AlreadyOptedOut),
-          ProcessedBulkOptOutResult("nino2", AlreadyOptedOut)
-        ),
-        expectedErrors = List("The following uploaded entries were not fully opted in"),
-        successCount = 0
-      )
-    }
-
-    "return 200 when only valid entries were parsed but were not found" in new TestCase {
-      val ninos = List(
-        "nino1",
-        "nino2"
-      )
-
-      testValidParsing(
-        controller = controller,
-        mockBulkOptOutsService = mockBulkOptOutsService,
-        ninos = ninos,
-        serverResponse = List(
-          ProcessedBulkOptOutResult("nino1", PreferenceNotFound),
-          ProcessedBulkOptOutResult("nino2", PreferenceNotFound)
-        ),
-        expectedErrors = List("The following uploaded entries were not found"),
-        successCount = 0
-      )
-    }
-
-    "return 200 when only valid entries were parsed but failed for unknown reasons" in new TestCase {
-      val ninos = List(
-        "nino1",
-        "nino2"
-      )
-
-      testValidParsing(
-        controller = controller,
-        mockBulkOptOutsService = mockBulkOptOutsService,
-        ninos = ninos,
-        serverResponse = List(
-          FailedCallBulkOptOutResult("nino1"),
-          FailedCallBulkOptOutResult("nino2")
-        ),
-        expectedErrors = List("The following entries failed for unexpected reasons"),
-        successCount = 0
-      )
-    }
-
-    "return 200 when only valid entries were parsed but failed due to an invalid formatted Nino value" in new TestCase {
-      val ninos = List(
-        "nino1",
-        "nino2"
-      )
-
-      testValidParsing(
-        controller = controller,
-        mockBulkOptOutsService = mockBulkOptOutsService,
-        ninos = ninos,
-        serverResponse = List(
-          InvalidNinoBulkOptOutResult("nino1"),
-          InvalidNinoBulkOptOutResult("nino2")
-        ),
-        expectedErrors = List("The following uploaded entries were in an invalid Nino format"),
-        successCount = 0
-      )
-    }
-
-    "return 200 and display all combinations of reponses" in new TestCase {
-      val ninos = List(
-        "nino1",
-        "nino2",
-        "nino3",
-        "nino4",
-        "nino5",
-        "nino6",
-        "nino7",
-        "nino8",
-        "nino9"
-      )
-
-      testValidParsing(
-        controller = controller,
-        mockBulkOptOutsService = mockBulkOptOutsService,
-        ninos = ninos,
-        serverResponse = List(
-          ProcessedBulkOptOutResult("nino1", PreferenceNotFound),
-          ProcessedBulkOptOutResult("nino2", OptedOut),
-          FailedCallBulkOptOutResult("nino3"),
-          FailedCallBulkOptOutResult("nino3"),
-          FailedCallBulkOptOutResult("nino4"),
-          ProcessedBulkOptOutResult("nino5", AlreadyOptedOut),
-          ProcessedBulkOptOutResult("nino6", AlreadyOptedOut),
-          ProcessedBulkOptOutResult("nino7", OptedOut),
-          ProcessedBulkOptOutResult("nino8", OptedOut),
-          InvalidNinoBulkOptOutResult("nino9")
-        ),
-        expectedErrors = List(
-          "The following uploaded entries were in an invalid Nino format",
-          "The following uploaded entries were not fully opted in",
-          "The following uploaded entries were not found",
-          "The following entries failed for unexpected reasons"
-        ),
-        successCount = 3
-      )
-    }
-
-  }
-
   class TestCase {
     lazy val mockUploadService: UploadService = mock[UploadService]
-    lazy val mockBulkOptOutsService: BulkUploadOptOutsService = mock[BulkUploadOptOutsService]
 
     implicit lazy val app: Application = GuiceApplicationBuilder()
       .overrides(inject.bind[UploadService].toInstance(mockUploadService))
-      .overrides(inject.bind[BulkUploadOptOutsService].toInstance(mockBulkOptOutsService))
       .build()
 
     implicit val hc: HeaderCarrier = HeaderCarrier()

--- a/test/uk/gov/hmrc/preferencesadminfrontend/controllers/LoginControllerSpec.scala
+++ b/test/uk/gov/hmrc/preferencesadminfrontend/controllers/LoginControllerSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.preferencesadminfrontend.controllers
 
 import org.apache.pekko.stream.Materializer
+import org.apache.pekko.util.ByteString
 import org.mockito.ArgumentMatchers.*
 import org.mockito.Mockito.*
 import org.scalatest.concurrent.ScalaFutures
@@ -26,6 +27,8 @@ import play.api.Application
 import play.api.http.*
 import play.api.i18n.MessagesApi
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.streams.Accumulator
+import play.api.mvc.{ Action, AnyContent, AnyContentAsFormUrlEncoded, Request, RequestHeader, Result }
 import play.api.test.CSRFTokenHelper.*
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
@@ -96,6 +99,22 @@ class LoginControllerSpec extends PlaySpec with GuiceOneAppPerSuite with SpecBas
       session(result).data must contain("userId" -> "solsUser")
       session(result).data must contain("isAdmin" -> "false")
       session(result).data must contain("isSols" -> "true")
+    }
+
+    "Set the session param for generic user role" in new MessageBrakeControllerTestCase {
+      val fakeRequest =
+        FakeRequest(routes.LoginController.loginAction())
+          .withFormUrlEncodedBody("username" -> "solsUser", "password" -> "pwd")
+          .withCSRFToken
+
+      val result = loginController.loginAction()(fakeRequest)
+
+      status(result) mustBe Status.SEE_OTHER
+      headers(result) must contain("Location" -> "/paperless/admin/home")
+      session(result).data must contain("userId" -> "solsUser")
+      session(result).data must contain("isAdmin" -> "false")
+      session(result).data must contain("isSols" -> "true")
+      session(result).data must contain("isGeneric" -> "true")
     }
 
     "Return unauthorised if credentials are not correct" in new MessageBrakeControllerTestCase {

--- a/test/uk/gov/hmrc/preferencesadminfrontend/controllers/LoginControllerSpec.scala
+++ b/test/uk/gov/hmrc/preferencesadminfrontend/controllers/LoginControllerSpec.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.preferencesadminfrontend.controllers
 
 import org.apache.pekko.stream.Materializer
-import org.apache.pekko.util.ByteString
 import org.mockito.ArgumentMatchers.*
 import org.mockito.Mockito.*
 import org.scalatest.concurrent.ScalaFutures
@@ -27,8 +26,6 @@ import play.api.Application
 import play.api.http.*
 import play.api.i18n.MessagesApi
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.streams.Accumulator
-import play.api.mvc.{ Action, AnyContent, AnyContentAsFormUrlEncoded, Request, RequestHeader, Result }
 import play.api.test.CSRFTokenHelper.*
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*

--- a/test/uk/gov/hmrc/preferencesadminfrontend/utils/ViewSpecBase.scala
+++ b/test/uk/gov/hmrc/preferencesadminfrontend/utils/ViewSpecBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/preferencesadminfrontend/utils/ViewSpecBase.scala
+++ b/test/uk/gov/hmrc/preferencesadminfrontend/utils/ViewSpecBase.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.preferencesadminfrontend.utils
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.test.FakeRequest
+import play.api.i18n.{ Messages, MessagesApi }
+import uk.gov.hmrc.preferencesadminfrontend.config.AppConfig
+
+trait ViewSpecBase extends AnyWordSpec with GuiceOneAppPerSuite with Matchers {
+  implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+  implicit val messages: Messages = messagesApi.preferred(FakeRequest())
+
+  implicit lazy val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+}

--- a/test/uk/gov/hmrc/preferencesadminfrontend/views/HomeViewSpec.scala
+++ b/test/uk/gov/hmrc/preferencesadminfrontend/views/HomeViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/preferencesadminfrontend/views/HomeViewSpec.scala
+++ b/test/uk/gov/hmrc/preferencesadminfrontend/views/HomeViewSpec.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.preferencesadminfrontend.views
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.{ Document, Element }
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
+import uk.gov.hmrc.preferencesadminfrontend.controllers.routes
+import uk.gov.hmrc.preferencesadminfrontend.utils.ViewSpecBase
+import uk.gov.hmrc.preferencesadminfrontend.views.html.home
+import play.api.test.FakeRequest
+import uk.gov.hmrc.preferencesadminfrontend.controllers.model.User
+import play.twirl.api.Html
+
+class HomeViewSpec extends ViewSpecBase {
+
+  "view" should {
+
+    "display the correct contents for admin role" in {
+      implicit val req: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+        .withSession((User.sessionKey, "admin"), ("isAdmin", "true"), ("isGeneric", "false"), ("isSols", "false"))
+
+      viewAsDocument.getElementsByTag("h1").text() shouldBe "Home"
+      viewAsDocument
+        .getElementsByTag("p")
+        .get(0)
+        .text() shouldBe "You can access the following control pages by clicking on the appropriate link"
+
+      val ulElelemt: Element = viewAsDocument.getElementsByTag("ul").get(0)
+      val liElements = ulElelemt.getElementsByTag("li")
+
+      liElements.get(0).text() shouldBe "Paperless Admin"
+      liElements.get(1).text() shouldBe "Message Brake"
+      liElements.get(2).text() shouldBe "Message Brake Allowlist"
+      liElements.get(3).text() shouldBe "Message Decode"
+      liElements.get(4).text() shouldBe "Multi Search"
+      liElements.get(5).text() shouldBe "File Upload Id Updates"
+      liElements.get(6).text() shouldBe "Bulk Opt Out"
+    }
+
+    "display the correct contents for generic role" in {
+      implicit val req: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+        .withSession((User.sessionKey, "solsUser"), ("isAdmin", "false"), ("isGeneric", "true"), ("isSols", "false"))
+
+      viewAsDocument.getElementsByTag("h1").text() shouldBe "Home"
+      viewAsDocument
+        .getElementsByTag("p")
+        .get(0)
+        .text() shouldBe "You can access the following control pages by clicking on the appropriate link"
+
+      val ulElelemt: Element = viewAsDocument.getElementsByTag("ul").get(0)
+      val liElements = ulElelemt.getElementsByTag("li")
+
+      liElements.get(0).text() shouldBe "Paperless Admin"
+      liElements.get(1).text() shouldBe "Bulk Opt Out"
+    }
+
+    "display the correct contents for sols role" in {
+      implicit val req: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+        .withSession((User.sessionKey, "solsUser"), ("isSols", "true"), ("isAdmin", "false"), ("isGeneric", "false"))
+
+      viewAsDocument.getElementsByTag("h1").text() shouldBe "Home"
+      viewAsDocument
+        .getElementsByTag("p")
+        .get(0)
+        .text() shouldBe "You can access the following control pages by clicking on the appropriate link"
+
+      val ulElelemt: Element = viewAsDocument.getElementsByTag("ul").get(0)
+      val liElements = ulElelemt.getElementsByTag("li")
+
+      liElements.get(0).text() shouldBe "Paperless Admin"
+    }
+  }
+
+  private def viewAsDocument(implicit request: FakeRequest[AnyContentAsEmpty.type]) = {
+    val homeView: home = app.injector.instanceOf[home]
+    Jsoup.parse(homeView.apply().body)
+  }
+}


### PR DESCRIPTION
Description - Code changes to enable Bulk Opt out option for Generic Role. So now bulk opt-out option is enabled for both admin and generic role.

 Below has been done as part of this PR

- new controller named CsvUploadBulkOptOutsController (with role Generic) has been created that contains all the functionality for bulk opt-outs, this functionality was earlier part of CsvUploadController.
- add tests and relevant code changes (add session param named isGeneric for generic role)
- add ViewSpecBase to keep common code for view tests
- minor refactoring
- add two test users in application.conf