### PR TITLE
[DC-9225] - The bulk opt-outs option is displayed for the sols user who has sols and generic roles

### DIFF
--- a/app/uk/gov/hmrc/preferencesadminfrontend/controllers/AuthorisedAction.scala
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/controllers/AuthorisedAction.scala
@@ -37,19 +37,19 @@ class AuthorisedAction @Inject() (loginService: LoginService, val controllerComp
       val user = request.session.get(User.sessionKey).map(name => User(name, ""))
 
       user match {
-        case Some(user) if checkForRequiredRoleAndBulkOptOutsAccess(user, role) || isAdmin => block(request)(user)
+        case Some(user) if hasRequiredRoleOrBulkOptOutsAccess(user, role) || isAdmin => block(request)(user)
         case _ => Future.successful(Redirect(routes.LoginController.showLoginPage()))
       }
     }
 
-  private def checkForRequiredRoleAndBulkOptOutsAccess(user: User, role: Role)(implicit request: Request[_]) =
+  private def hasRequiredRoleOrBulkOptOutsAccess(user: User, role: Role)(implicit request: Request[_]) =
     if (request.uri.equals(routes.CsvUploadBulkOptOutsController.showBulkOptOutsUploadPage.url)) {
-      loginService.hasRequiredRole(user, role) && checkAccessForCsvUploadBulkOptOuts
+      loginService.hasRequiredRole(user, role) && hasAccessForCsvUploadBulkOptOuts
     } else {
       loginService.hasRequiredRole(user, role)
     }
 
-  private def checkAccessForCsvUploadBulkOptOuts(implicit request: Request[_]): Boolean = {
+  private def hasAccessForCsvUploadBulkOptOuts(implicit request: Request[_]): Boolean = {
     val isAdmin = request.session.get("isAdmin").getOrElse("false").toBoolean
     val isGeneric = request.session.get("isGeneric").getOrElse("false").toBoolean
     val isSols = request.session.get("isSols").getOrElse("false").toBoolean

--- a/app/uk/gov/hmrc/preferencesadminfrontend/controllers/AuthorisedAction.scala
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/controllers/AuthorisedAction.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.preferencesadminfrontend.controllers
 
-import play.api.mvc.{ Action, AnyContent, MessagesBaseController, MessagesControllerComponents, Request, Result }
+import play.api.mvc.{ Action, AnyContent, MessagesBaseController, MessagesControllerComponents, MessagesRequest, Request, Result }
 import uk.gov.hmrc.preferencesadminfrontend.controllers.Role.Generic
 import uk.gov.hmrc.preferencesadminfrontend.controllers.model.User
 import uk.gov.hmrc.preferencesadminfrontend.services.LoginService
@@ -29,14 +29,33 @@ class AuthorisedAction @Inject() (loginService: LoginService, val controllerComp
 
   def async(block: Request[AnyContent] => User => Future[Result]): Action[AnyContent] = async(Generic)(block)
 
-  def async(role: Role)(block: Request[AnyContent] => User => Future[Result]): Action[AnyContent] =
+  def async(role: Role)(
+    block: Request[AnyContent] => User => Future[Result]
+  ): Action[AnyContent] =
     Action.async { implicit request =>
       val isAdmin = request.session.get("isAdmin").getOrElse("false").toBoolean
       val user = request.session.get(User.sessionKey).map(name => User(name, ""))
 
       user match {
-        case Some(user) if loginService.hasRequiredRole(user, role) || isAdmin => block(request)(user)
+        case Some(user) if checkForRequiredRoleAndBulkOptOutsAccess(user, role) || isAdmin => block(request)(user)
         case _ => Future.successful(play.api.mvc.Results.Redirect(routes.LoginController.showLoginPage()))
       }
     }
+
+  private def checkForRequiredRoleAndBulkOptOutsAccess(user: User, role: Role)(implicit
+    request: MessagesRequest[AnyContent]
+  ) =
+    if (request.uri.equals(routes.CsvUploadBulkOptOutsController.showBulkOptOutsUploadPage.url)) {
+      loginService.hasRequiredRole(user, role) && checkAccessForCsvUploadBulkOptOuts
+    } else {
+      loginService.hasRequiredRole(user, role)
+    }
+
+  private def checkAccessForCsvUploadBulkOptOuts(implicit request: MessagesRequest[AnyContent]): Boolean = {
+    val isAdmin = request.session.get("isAdmin").getOrElse("false").toBoolean
+    val isGeneric = request.session.get("isGeneric").getOrElse("false").toBoolean
+    val isSols = request.session.get("isSols").getOrElse("false").toBoolean
+
+    (isGeneric || isAdmin) && (!isSols)
+  }
 }

--- a/app/uk/gov/hmrc/preferencesadminfrontend/controllers/AuthorisedAction.scala
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/controllers/AuthorisedAction.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.preferencesadminfrontend.controllers
 
-import play.api.mvc.{ Action, AnyContent, MessagesBaseController, MessagesControllerComponents, MessagesRequest, Request, Result }
+import play.api.mvc.{ Action, AnyContent, MessagesBaseController, MessagesControllerComponents, Request, Result }
 import uk.gov.hmrc.preferencesadminfrontend.controllers.Role.Generic
 import uk.gov.hmrc.preferencesadminfrontend.controllers.model.User
 import uk.gov.hmrc.preferencesadminfrontend.services.LoginService
@@ -38,20 +38,18 @@ class AuthorisedAction @Inject() (loginService: LoginService, val controllerComp
 
       user match {
         case Some(user) if checkForRequiredRoleAndBulkOptOutsAccess(user, role) || isAdmin => block(request)(user)
-        case _ => Future.successful(play.api.mvc.Results.Redirect(routes.LoginController.showLoginPage()))
+        case _ => Future.successful(Redirect(routes.LoginController.showLoginPage()))
       }
     }
 
-  private def checkForRequiredRoleAndBulkOptOutsAccess(user: User, role: Role)(implicit
-    request: MessagesRequest[AnyContent]
-  ) =
+  private def checkForRequiredRoleAndBulkOptOutsAccess(user: User, role: Role)(implicit request: Request[_]) =
     if (request.uri.equals(routes.CsvUploadBulkOptOutsController.showBulkOptOutsUploadPage.url)) {
       loginService.hasRequiredRole(user, role) && checkAccessForCsvUploadBulkOptOuts
     } else {
       loginService.hasRequiredRole(user, role)
     }
 
-  private def checkAccessForCsvUploadBulkOptOuts(implicit request: MessagesRequest[AnyContent]): Boolean = {
+  private def checkAccessForCsvUploadBulkOptOuts(implicit request: Request[_]): Boolean = {
     val isAdmin = request.session.get("isAdmin").getOrElse("false").toBoolean
     val isGeneric = request.session.get("isGeneric").getOrElse("false").toBoolean
     val isSols = request.session.get("isSols").getOrElse("false").toBoolean

--- a/app/uk/gov/hmrc/preferencesadminfrontend/views/home.scala.html
+++ b/app/uk/gov/hmrc/preferencesadminfrontend/views/home.scala.html
@@ -54,7 +54,9 @@
                 </li>
             }
 
-            @if(TemplateHelper.validateRole(request.session, "isAdmin") || TemplateHelper.validateRole(request.session, "isGeneric")) {
+            @if((TemplateHelper.validateRole(request.session, "isAdmin")
+                || TemplateHelper.validateRole(request.session, "isGeneric"))
+                    && !TemplateHelper.validateRole(request.session, "isSols")) {
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
                     <a class="govuk-link govuk-task-list__link" href="/paperless/admin/csv-upload-bulk-opt-outs">Bulk Opt Out</a>
                 </li>

--- a/test/uk/gov/hmrc/preferencesadminfrontend/views/HomeViewSpec.scala
+++ b/test/uk/gov/hmrc/preferencesadminfrontend/views/HomeViewSpec.scala
@@ -85,6 +85,28 @@ class HomeViewSpec extends ViewSpecBase {
 
       liElements.get(0).text() shouldBe "Paperless Admin"
     }
+
+    "do not display the bulk opt-outs option for a user which has both sols and generic roles" in {
+      implicit val req: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+        .withSession((User.sessionKey, "solsUser"), ("isSols", "true"), ("isAdmin", "false"), ("isGeneric", "true"))
+
+      viewAsDocument.getElementsByTag("h1").text() shouldBe "Home"
+      viewAsDocument
+        .getElementsByTag("p")
+        .get(0)
+        .text() shouldBe "You can access the following control pages by clicking on the appropriate link"
+
+      val ulElelemt: Element = viewAsDocument.getElementsByTag("ul").get(0)
+      val liElements = ulElelemt.getElementsByTag("li")
+
+      liElements.get(0).text() shouldBe "Paperless Admin"
+
+      viewAsDocument.text() should not include "Bulk Opt Out"
+
+      intercept[IndexOutOfBoundsException] {
+        liElements.get(1).text()
+      }
+    }
   }
 
   private def viewAsDocument(implicit request: FakeRequest[AnyContentAsEmpty.type]) = {


### PR DESCRIPTION
Description - Code changes for not to display the csv bulk opt-outs option if a user has both sols and generic role as user should only allow to perform this functionality if the user has only generic role

Below has been done as part of this PR

- add new test class for AuthorisedAction
- add a check in AuthorisedAction to allow/disallow to perform the bulk opt-outs functionality (it has been done like this as it is the quicker way right now but we need to find a elegant way to handle the roles and its usage across the service)

- Update home view not to display bulk opt-outs if user has both roles (sols and generic)
- minor refactoring